### PR TITLE
feat: support installing multiple formulas at once

### DIFF
--- a/zb_io/src/lib.rs
+++ b/zb_io/src/lib.rs
@@ -16,7 +16,7 @@ pub use cache::ApiCache;
 pub use db::{Database, InstalledKeg};
 pub use download::{DownloadProgressCallback, DownloadRequest, Downloader, ParallelDownloader};
 pub use extract::extract_tarball;
-pub use install::Installer;
+pub use install::{InstallPlan, Installer};
 pub use link::Linker;
 pub use materialize::Cellar;
 pub use progress::{InstallProgress, ProgressCallback};


### PR DESCRIPTION
## Summary

- Add `plan_multiple()` to resolve dependencies for multiple formulas efficiently (deduplicates shared deps)
- Refactor Install command to accept multiple formulas: `zb install wget jq ripgrep fd bat`
- Extract `create_progress_callback()` and `execute_install()` helpers to reduce code duplication

## Stack

```
main
└── multi-install  ← this PR
      └── alias-resolution
            └── brewfile-bundle
```

## Test plan

- [ ] `zb install wget` still works (single formula)
- [ ] `zb install wget jq ripgrep` installs all three with shared deps resolved once
- [ ] `cargo test` passes

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)