### PR TITLE
feat: Add multi-package install and uninstall support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,12 @@ This leads to dramatic speedups, up to 5x cold and 20x warm. Full benchmarks [he
 ##  Using `zb`
 
 ```bash
-zb install jq        # install jq
-zb install wget git  # install multiple
-zb uninstall jq      # uninstall
-zb reset         # uninstall everything
-zb gc                # garbage collect unused store entries
+zb install jq           # install jq
+zb install wget git     # install multiple
+zb uninstall jq         # uninstall jq
+zb uninstall jq wget    # uninstall multiple
+zb reset                # uninstall everything
+zb gc                   # garbage collect unused store entries
 ```
 
 ## Why is it faster?

--- a/zb_core/src/lib.rs
+++ b/zb_core/src/lib.rs
@@ -8,4 +8,4 @@ pub use bottle::{SelectedBottle, select_bottle};
 pub use context::{ConcurrencyLimits, Context, LogLevel, LoggerHandle, Paths};
 pub use errors::Error;
 pub use formula::Formula;
-pub use resolve::resolve_closure;
+pub use resolve::{resolve_closure, resolve_closure_multiple};

--- a/zb_core/src/resolve.rs
+++ b/zb_core/src/resolve.rs
@@ -8,7 +8,15 @@ pub fn resolve_closure(
     root: &str,
     formulas: &BTreeMap<String, Formula>,
 ) -> Result<Vec<String>, Error> {
-    let closure = compute_closure(root, formulas)?;
+    resolve_closure_multiple(&[root.to_string()], formulas)
+}
+
+/// Resolve dependencies for multiple root formulas, merging their dependency graphs
+pub fn resolve_closure_multiple(
+    roots: &[String],
+    formulas: &BTreeMap<String, Formula>,
+) -> Result<Vec<String>, Error> {
+    let closure = compute_closure_multiple(roots, formulas)?;
     let (mut indegree, adjacency) = build_graph(&closure, formulas)?;
 
     let mut ready: BTreeSet<String> = indegree
@@ -49,12 +57,12 @@ pub fn resolve_closure(
     Ok(ordered)
 }
 
-fn compute_closure(
-    root: &str,
+fn compute_closure_multiple(
+    roots: &[String],
     formulas: &BTreeMap<String, Formula>,
 ) -> Result<BTreeSet<String>, Error> {
     let mut closure = BTreeSet::new();
-    let mut stack = vec![root.to_string()];
+    let mut stack: Vec<String> = roots.to_vec();
 
     while let Some(name) = stack.pop() {
         if !closure.insert(name.clone()) {


### PR DESCRIPTION
## Summary
- Adds support for installing and uninstalling multiple packages in a single command
- Users can now run `zb install biome ffmpeg` instead of running separate commands

Fixes #18

## Test plan
- [ ] Test `zb install pkg1 pkg2` installs both packages
- [ ] Test `zb uninstall pkg1 pkg2` uninstalls both packages
- [ ] Test single package install/uninstall still works