### PR TITLE
bugfix: Fix progress bar UI synchronization and resource cleanup

### DIFF
--- a/zb_io/src/install.rs
+++ b/zb_io/src/install.rs
@@ -329,6 +329,11 @@ impl Installer {
                         Vec::new()
                     };
 
+                    // Report installation completed for this package
+                    report(InstallProgress::InstallCompleted {
+                        name: formula.name.clone(),
+                    });
+
                     completed[idx] = Some(ProcessedPackage {
                         name: formula.name.clone(),
                         version: formula.effective_version(),

--- a/zb_io/src/progress.rs
+++ b/zb_io/src/progress.rs
@@ -22,6 +22,8 @@ pub enum InstallProgress {
     LinkStarted { name: String },
     /// Linking completed for a package
     LinkCompleted { name: String },
+    /// Installation completed for a package (final state)
+    InstallCompleted { name: String },
 }
 
 /// Callback type for progress reporting


### PR DESCRIPTION
## Summary
Fixes UI state synchronization issues and improper resource cleanup that causes progress bars to display incorrect status or remain active after errors.

**Problems fixed:**
- **Premature UI update**: `UnpackCompleted` was setting status to "linking..." immediately, leaving UI stuck if `--no-link` is used
- **Missing completion event**: No explicit "Installation Finished" event - CLI relied on `LinkCompleted` which never fires with `--no-link`
- **Visual artifacts on error**: If installation fails, progress bars weren't cleaned up before returning, leaving spinners frozen
- **Resource leak**: Racing downloads were just dropped instead of explicitly aborted

**Changes:**
1. `zb_io/src/progress.rs`: Added `InstallCompleted` event variant
2. `zb_cli/src/main.rs`: 
   - `UnpackCompleted` now shows "unpacked" instead of "linking..."
   - `LinkCompleted` now shows "linked" (no longer finishes the bar)
   - `InstallCompleted` finishes the progress bar with "✓ installed"
   - Progress bars cleaned up BEFORE error handling
3. `zb_io/src/install.rs`: Emit `InstallCompleted` after each package is processed
4. `zb_io/src/download.rs`: Explicitly abort remaining racing tasks on success

## Test plan
- [x] Test `zb install pkg` - progress bar should complete correctly
- [x] Test `zb install nonexistent-pkg` - spinners should stop cleanly before error
- [x] Test normal install - should show proper progression: downloading → unpacking → linking → installed