### PR TITLE
bugfix: Fix version regex bug in text file placeholder patching

### DIFF
--- a/zb_io/src/materialize.rs
+++ b/zb_io/src/materialize.rs
@@ -63,6 +63,10 @@ impl Cellar {
         #[cfg(target_os = "macos")]
         patch_homebrew_placeholders(&keg_path, &self.cellar_dir, name, version)?;
 
+        // Patch Homebrew placeholders in text files (shell scripts, etc.)
+        #[cfg(target_os = "macos")]
+        patch_text_file_placeholders(&keg_path, &self.cellar_dir, name, version)?;
+
         // Strip quarantine xattrs and ad-hoc sign Mach-O binaries
         #[cfg(target_os = "macos")]
         codesign_and_strip_xattrs(&keg_path)?;
@@ -306,6 +310,132 @@ fn patch_homebrew_placeholders(
         return Err(Error::StoreCorruption {
             message: format!(
                 "failed to patch {} Mach-O files in {}",
+                failures,
+                keg_path.display()
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+/// Patch @@HOMEBREW_CELLAR@@ and @@HOMEBREW_PREFIX@@ placeholders in text files.
+/// This handles shell scripts and other text files that contain Homebrew placeholders.
+/// Uses rayon for parallel processing.
+#[cfg(target_os = "macos")]
+fn patch_text_file_placeholders(
+    keg_path: &Path,
+    cellar_dir: &Path,
+    _pkg_name: &str,
+    _pkg_version: &str,
+) -> Result<(), Error> {
+    use rayon::prelude::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Derive prefix from cellar (cellar_dir is typically prefix/cellar)
+    let prefix = cellar_dir.parent().unwrap_or(Path::new("/opt/homebrew"));
+
+    let cellar_str = cellar_dir.to_string_lossy().to_string();
+    let prefix_str = prefix.to_string_lossy().to_string();
+
+    // Collect text files that contain placeholders (skip symlinks and binaries)
+    let text_files: Vec<PathBuf> = walkdir::WalkDir::new(keg_path)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .filter(|e| {
+            if let Ok(data) = fs::read(e.path()) {
+                // Skip empty files
+                if data.is_empty() {
+                    return false;
+                }
+                // Skip binary files (check magic bytes for Mach-O)
+                if data.len() >= 4 {
+                    let magic = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+                    if matches!(
+                        magic,
+                        0xfeedface | 0xfeedfacf | 0xcafebabe | 0xcefaedfe | 0xcffaedfe
+                    ) {
+                        return false;
+                    }
+                }
+                // Check if file contains placeholders we need to fix
+                let content = String::from_utf8_lossy(&data);
+                content.contains("@@HOMEBREW_CELLAR@@") || content.contains("@@HOMEBREW_PREFIX@@")
+            } else {
+                false
+            }
+        })
+        .map(|e| e.path().to_path_buf())
+        .collect();
+
+    // Track patch failures
+    let patch_failures = AtomicUsize::new(0);
+
+    // Process text files in parallel
+    text_files.par_iter().for_each(|path| {
+        // Read file content
+        let content = match fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => {
+                // File might not be valid UTF-8, skip it
+                return;
+            }
+        };
+
+        let mut new_content = content.clone();
+
+        // Replace Homebrew placeholders
+        new_content = new_content
+            .replace("@@HOMEBREW_CELLAR@@", &cellar_str)
+            .replace("@@HOMEBREW_PREFIX@@", &prefix_str);
+
+        // Only write if content changed
+        if new_content == content {
+            return;
+        }
+
+        // Get file permissions and make writable if needed
+        let metadata = match fs::metadata(path) {
+            Ok(m) => m,
+            Err(_) => {
+                patch_failures.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        };
+        let original_mode = metadata.permissions().mode();
+        let is_readonly = original_mode & 0o200 == 0;
+
+        // Make writable for patching
+        if is_readonly {
+            let mut perms = metadata.permissions();
+            perms.set_mode(original_mode | 0o200);
+            if fs::set_permissions(path, perms).is_err() {
+                patch_failures.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        }
+
+        // Write patched content
+        if fs::write(path, &new_content).is_err() {
+            patch_failures.fetch_add(1, Ordering::Relaxed);
+        }
+
+        // Restore original permissions
+        if is_readonly {
+            let mut perms = metadata.permissions();
+            perms.set_mode(original_mode);
+            let _ = fs::set_permissions(path, perms);
+        }
+    });
+
+    let failures = patch_failures.load(Ordering::Relaxed);
+    if failures > 0 {
+        return Err(Error::StoreCorruption {
+            message: format!(
+                "failed to patch {} text files in {}",
                 failures,
                 keg_path.display()
             ),


### PR DESCRIPTION
## Summary
- Remove version mismatch regex from text file patching to prevent path corruption
- Text files now only replace `@@HOMEBREW_CELLAR@@` and `@@HOMEBREW_PREFIX@@` placeholders
- Version mismatch fixing remains in Mach-O binary patching where it's safe

## Test plan
- [x] `cargo build` passes
- [x] `cargo test -p zb_io` passes (60 tests)
- [x] `cargo clippy` passes with no warnings
- [x] Manual test: `zb uninstall mole && zb install mole && mo --version`

Fixes #31