### PR TITLE
bugfix: Add MSRV 1.90 to fix let chains compilation error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 members = ["zb_core", "zb_io", "zb_cli"]
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.90"
+
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/zb_cli/Cargo.toml
+++ b/zb_cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zb_cli"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [[bin]]
 name = "zb"

--- a/zb_core/Cargo.toml
+++ b/zb_core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zb_core"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }

--- a/zb_io/Cargo.toml
+++ b/zb_io/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zb_io"
 version = "0.1.0"
 edition = "2024"
+rust-version.workspace = true
 
 [dependencies]
 flate2 = "1.0"


### PR DESCRIPTION
## Summary
- Adds `rust-version = "1.90"` to workspace and all crates
- Fixes compilation errors for users on older Rust versions by providing a clear MSRV error instead of cryptic "unstable feature" messages

Fixes #17

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (71 tests)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes