### PR TITLE
config: workspace organization and resolver bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,35 @@
 [workspace]
 members = ["zb_core", "zb_io", "zb_cli"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 rust-version = "1.90"
+
+[workspace.dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "fs"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+clap = { version = "4", features = ["derive"] }
+console = "0.15"
+indicatif = "0.17"
+reqwest = { version = "0.12", features = ["json", "stream"] }
+flate2 = "1.0"
+tar = "0.4"
+xz2 = "0.1"
+zstd = "0.13"
+rusqlite = { version = "0.32", features = ["bundled"] }
+futures = "0.3"
+futures-util = "0.3"
+rayon = "1.10"
+regex = "1"
+sha2 = "0.10"
+walkdir = "2"
+fs4 = "0.13"
+libc = "0.2"
+
+# Dev dependencies
+tempfile = "3"
+wiremock = "0.6"
 
 [profile.release]
 opt-level = 3

--- a/zb_cli/Cargo.toml
+++ b/zb_cli/Cargo.toml
@@ -9,13 +9,13 @@ name = "zb"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
-indicatif = "0.17"
-console = "0.15"
+clap.workspace = true
+tokio = { workspace = true, features = ["full"] }
+indicatif.workspace = true
+console.workspace = true
 
 zb_core = { path = "../zb_core" }
 zb_io = { path = "../zb_io" }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc.workspace = true

--- a/zb_core/Cargo.toml
+++ b/zb_core/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 rust-version.workspace = true
 
 [dependencies]
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0.140"
+serde.workspace = true
+serde_json.workspace = true

--- a/zb_io/Cargo.toml
+++ b/zb_io/Cargo.toml
@@ -5,25 +5,25 @@ edition = "2024"
 rust-version.workspace = true
 
 [dependencies]
-flate2 = "1.0"
-futures = "0.3"
-libc = "0.2"
-futures-util = "0.3"
-rayon = "1.10"
-regex = "1"
-reqwest = { version = "0.12", features = ["json", "stream"] }
-rusqlite = { version = "0.32", features = ["bundled"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-sha2 = "0.10"
-tar = "0.4"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "fs"] }
-fs4 = "0.13"
-walkdir = "2"
-xz2 = "0.1"
-zstd = "0.13"
+flate2.workspace = true
+futures.workspace = true
+libc.workspace = true
+futures-util.workspace = true
+rayon.workspace = true
+regex.workspace = true
+reqwest.workspace = true
+rusqlite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tar.workspace = true
+tokio.workspace = true
+fs4.workspace = true
+walkdir.workspace = true
+xz2.workspace = true
+zstd.workspace = true
 zb_core = { path = "../zb_core" }
 
 [dev-dependencies]
-tempfile = "3"
-wiremock = "0.6"
+tempfile.workspace = true
+wiremock.workspace = true


### PR DESCRIPTION
This PR centralizes shared dependencies in `workspace.dependencies` and upgrades the resolver to v3 since it's been the default since 1.84 -> https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html