### PR TITLE
Fix path export and update _zb_path_append function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,6 +69,11 @@ case "$SHELL" in
         ;;
 esac
 
+if [[ ! -w $SHELL_CONFIG ]]; then
+    echo "Error, config not writable: $SHELL_CONFIG" >&2
+    exit 1
+fi
+
 # Add to PATH in shell config if not already there
 PATHS_TO_ADD=("$ZEROBREW_BIN" "/opt/zerobrew/prefix/bin")
 if ! grep -q "^# zerobrew$" "$SHELL_CONFIG" 2>/dev/null; then


### PR DESCRIPTION
Updated the install script to persist & export ZEROBREW_DIR and ZEROBREW_BIN. Modified the _zb_path_append function to handle variable paths, as expected

Fixing previous commit