### PR TITLE
fix(zb_core): use revision instead of rebuild for bottle path

### DIFF
--- a/zb_core/src/bottle.rs
+++ b/zb_core/src/bottle.rs
@@ -95,6 +95,7 @@ mod tests {
             bottle: Bottle {
                 stable: BottleStable { files, rebuild: 0 },
             },
+            revision: 0,
         };
 
         let selected = select_bottle(&formula).unwrap();
@@ -123,6 +124,7 @@ mod tests {
             bottle: Bottle {
                 stable: BottleStable { files, rebuild: 0 },
             },
+            revision: 0,
         };
 
         let err = select_bottle(&formula).unwrap_err();

--- a/zb_core/src/resolve.rs
+++ b/zb_core/src/resolve.rs
@@ -129,6 +129,7 @@ mod tests {
             bottle: Bottle {
                 stable: BottleStable { files, rebuild: 0 },
             },
+            revision: 0,
         }
     }
 


### PR DESCRIPTION
# Fix: Use Formula Revision for Bottle Installation Path

## Problem
Zerobrew was creating installation directories that included the bottle [rebuild](https://github.com/lucasgelfond/zerobrew/blob/fix/correct-bottle-installation-path/zb_core/src/formula.rs:90:4-99:5) number (e.g., `0.16.0_1`) even when the formula [revision](https://github.com/lucasgelfond/zerobrew/blob/fix/correct-bottle-installation-path/zb_core/src/formula.rs:3840:4-3842:7) was 0. This caused errors for packages like `ramalama` because the internal scripts/binaries expected the path to be the un-suffixed version (e.g., `0.16.0`).

## Solution
Updated `Formula::effective_version` in [zb_core/src/formula.rs](https://github.com/lucasgelfond/zerobrew/blob/fix/correct-bottle-installation-path/zb_core/src/formula.rs) to use the [revision](cci:1://file:///home/james/dev/zerobrew/.homebrew-reference/Library/Homebrew/formula.rb:3840:4-3842:7) field instead of `bottle.rebuild` when determining the version string for the installation directory. This ensures that:
- `revision: 0` -> `0.16.0`
- `revision: 1` -> `0.16.0_1`
- `rebuild: 1` (w/ revision 0) -> `0.16.0` (Correct behavior)

## Justification
This change aligns Zerobrew with Homebrew's internal logic, where the installation path (keg version) is derived strictly from the formula version and revision, ignoring bottle rebuilds.

**References:**
1.  **[Library/Homebrew/formula.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formula.rb#L642)**: The [pkg_version](cci:1://file:///home/james/dev/zerobrew/.homebrew-reference/Library/Homebrew/formula.rb:641:2-641:53) is constructed using only `version` and `revision`.
    ```ruby
    def pkg_version = PkgVersion.new(version, revision)
    ```
2.  **[Library/Homebrew/pkg_version.rb](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/pkg_version.rb#L41-L47)**: The string representation appends `_{revision}` only if [revision](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/formula.rb#L3841) is positive. It does not look at bottle rebuilds.
    ```ruby
    def to_str
      if revision.positive?
        "#{version}_#{revision}"
      else
        version.to_s
      end
    end
    ```

## Verification
- Verified manually by installing `ramalama` (bottle rebuild: 1).
- Installation directory is now correctly `$ZEROBREW_PREFIX/Cellar/ramalama/0.16.0`.
