### PR TITLE
chore(README.md): add uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ cargo install --path zb_cli
 ./benchmark.sh -h                             # show help
 ```
 
+## Uninstall
+```bash
+~/.zerobrew/remove-zerobrew
+```
+
 ## Status
 
 Experimental. works for most core homebrew packages. Some formulas may need more work - please submit issues / PRs! 


### PR DESCRIPTION
Adds instructions how to uninstall zerobrew to README. Supersedes #89 as the commit there did not follow the naming conventions - apologies.