### PR TITLE
Removing Allocation in DependencyCycle

### DIFF
--- a/zb_core/src/errors.rs
+++ b/zb_core/src/errors.rs
@@ -36,8 +36,14 @@ impl fmt::Display for Error {
                 )
             }
             Error::DependencyCycle { cycle } => {
-                let rendered = cycle.join(" -> ");
-                write!(f, "dependency cycle detected: {rendered}")
+                write!(f, "dependency cycle detected: ")?;
+                for (i, item) in cycle.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " -> ")?;
+                    }
+                    write!(f, "{}", item)?;
+                }
+                Ok(())
             }
             Error::NotInstalled { name } => write!(f, "formula '{name}' is not installed"),
         }
@@ -57,5 +63,13 @@ mod tests {
         };
 
         assert!(err.to_string().contains("libheif"));
+    }
+
+    #[test]
+    fn dependency_cycle_display_format() {
+        let err = Error::DependencyCycle {
+            cycle: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+        };
+        assert_eq!(err.to_string(), "dependency cycle detected: a -> b -> c");
     }
 }


### PR DESCRIPTION
## Removing Allocation in DependencyCycle (1)

The use of .join() has been replaced by an iterator. The visual result (final string) is identical, but the memory cost is lower.

## Regression Test (2)

I added a dependency_cycle_display_format unit test to ensure that my optimization didn't break the error message format, since other services might "parse" (read) that text.