### PR TITLE
chore: remove `Justfile` ft specify

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,3 @@
-# vim: set ft=make :
-
 set export
 set dotenv-load
 set script-interpreter := ['bash', '-euo', 'pipefail']


### PR DESCRIPTION
`Just` have [syntax highlighting](https://github.com/casey/tree-sitter-just) and [lsp](https://github.com/terror/just-lsp), we may doesn't need to force specify this file type