### PR TITLE
fix(zb_io): HTTP/2 stream contention in rustls backend

### DIFF
--- a/zb_io/src/download.rs
+++ b/zb_io/src/download.rs
@@ -19,10 +19,7 @@ use zb_core::Error;
 
 /// Number of parallel connections to race when downloading (hits different CDN edges)
 /// Note: Racing is disabled on Linux due to HTTP/2 stream contention issues with rustls
-#[cfg(target_os = "linux")]
 const RACING_CONNECTIONS: usize = 1;
-#[cfg(not(target_os = "linux"))]
-const RACING_CONNECTIONS: usize = 4;
 
 /// Delay between starting each racing connection (ms)
 const RACING_STAGGER_MS: u64 = 200;


### PR DESCRIPTION
Fixes #113 