### PR TITLE
feat(zb_cli): support custom installation paths via environment variables and interactive init

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,10 @@ set -e
 # Usage: curl -sSL https://raw.githubusercontent.com/lucasgelfond/zerobrew/main/install.sh | bash
 
 ZEROBREW_REPO="https://github.com/lucasgelfond/zerobrew.git"
-: ${ZEROBREW_DIR:=$HOME/.zerobrew}
+: ${ZEROBREW_SRC:=$HOME/.zerobrew}
 : ${ZEROBREW_BIN:=$HOME/.local/bin}
+: ${ZEROBREW_ROOT:=/opt/zerobrew}
+: ${ZEROBREW_PREFIX:=$ZEROBREW_ROOT/prefix}
 
 echo "Installing zerobrew..."
 
@@ -26,21 +28,21 @@ fi
 echo "Rust version: $(rustc --version)"
 
 # Clone or update repo
-if [[ -d "$ZEROBREW_DIR" ]]; then
+if [[ -d "$ZEROBREW_SRC" ]]; then
     echo "Updating zerobrew..."
-    cd "$ZEROBREW_DIR"
+    cd "$ZEROBREW_SRC"
     git fetch --depth=1 origin main
     git reset --hard origin/main
 else
     echo "Cloning zerobrew..."
-    git clone --depth 1 "$ZEROBREW_REPO" "$ZEROBREW_DIR"
-    cd "$ZEROBREW_DIR"
+    git clone --depth 1 "$ZEROBREW_REPO" "$ZEROBREW_SRC"
+    cd "$ZEROBREW_SRC"
 fi
 
 # Build
 echo "Building zerobrew..."
-if [[ -d "/opt/zerobrew/prefix/lib/pkgconfig" ]]; then
-    export PKG_CONFIG_PATH="/opt/zerobrew/prefix/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+if [[ -d "$ZEROBREW_PREFIX/lib/pkgconfig" ]]; then
+    export PKG_CONFIG_PATH="$ZEROBREW_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 fi
 if [[ -d "/opt/homebrew/lib/pkgconfig" ]] && [[ ! "$PKG_CONFIG_PATH" =~ "/opt/homebrew/lib/pkgconfig" ]]; then
     export PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
@@ -80,49 +82,31 @@ if [[ ! -w $SHELL_CONFIG ]]; then
     exit 1
 fi
 
-# Add to PATH in shell config if not already there
-PATHS_TO_ADD=("$ZEROBREW_BIN" "/opt/zerobrew/prefix/bin")
-if ! grep -q "^# zerobrew$" "$SHELL_CONFIG" 2>/dev/null; then
+# Add zb binary to PATH (the main ZEROBREW_ROOT/PREFIX config is handled by `zb init`)
+if ! grep -q "$ZEROBREW_BIN" "$SHELL_CONFIG" 2>/dev/null; then
     cat >>"$SHELL_CONFIG" <<EOF
-# zerobrew
-export ZEROBREW_DIR=$ZEROBREW_DIR
-export ZEROBREW_BIN=$ZEROBREW_BIN
-export PKG_CONFIG_PATH="/opt/zerobrew/prefix/lib/pkgconfig:\${PKG_CONFIG_PATH:-}"
-_zb_path_append() {
-    local argpath="\$1"
-    case ":\${PATH}:" in
-        *:"\$argpath":*) ;;
-        *) export PATH="\$argpath:\$PATH" ;;
-    esac;
-}
+
+# zerobrew cli
+export PATH="$ZEROBREW_BIN:\$PATH"
 EOF
-    for path_entry in "${PATHS_TO_ADD[@]}"; do
-        if ! grep -q "$path_entry" "$SHELL_CONFIG" 2>/dev/null; then
-            echo "_zb_path_append $path_entry" >>"$SHELL_CONFIG"
-            echo "Added $path_entry to PATH in $SHELL_CONFIG"
-        fi
-    done
+    echo "Added $ZEROBREW_BIN to PATH in $SHELL_CONFIG"
 fi
 
 # Export for current session so zb init works
-export PATH="$ZEROBREW_BIN:/opt/zerobrew/prefix/bin:$PATH"
+export PATH="$ZEROBREW_BIN:$PATH"
 
-# Set up /opt/zerobrew directories with correct ownership
-echo ""
-echo "Setting up zerobrew directories..."
-CURRENT_USER=$(whoami)
-if [[ ! -d "/opt/zerobrew" ]] || [[ ! -w "/opt/zerobrew" ]]; then
-    echo "Creating /opt/zerobrew (requires sudo)..."
-    sudo mkdir -p /opt/zerobrew/store /opt/zerobrew/db /opt/zerobrew/cache /opt/zerobrew/locks
-    sudo mkdir -p /opt/zerobrew/prefix/bin /opt/zerobrew/prefix/Cellar
-    sudo chown -R "$CURRENT_USER" /opt/zerobrew
-    sudo chown -R "$CURRENT_USER" /opt/zerobrew/prefix
-fi
-
-# Run zb init to finalize setup
+# Run zb init to set up directories and configure ZEROBREW_ROOT/ZEROBREW_PREFIX
 echo ""
 echo "Running zb init..."
-"$ZEROBREW_BIN/zb" init
+echo "(You can customize the installation directory during init)"
+echo ""
+
+# If running via pipe (curl | bash), try to reconnect to TTY for interactive prompts
+if [ ! -t 0 ] && [ -e /dev/tty ]; then
+    "$ZEROBREW_BIN/zb" init < /dev/tty
+else
+    "$ZEROBREW_BIN/zb" init
+fi
 
 echo ""
 echo "============================================"
@@ -131,9 +115,9 @@ echo "============================================"
 echo ""
 echo "Run this to start using zerobrew now:"
 echo ""
-echo "    export PATH=\"$ZEROBREW_BIN:/opt/zerobrew/prefix/bin:\$PATH\""
+echo "    source $SHELL_CONFIG"
 echo ""
-echo "Or restart your terminal, to source updated ${SHELL_CONFIG}."
+echo "Or restart your terminal."
 echo ""
 echo "Then try: zb install ffmpeg"
 echo ""


### PR DESCRIPTION
- Add support for ZEROBREW_ROOT and ZEROBREW_PREFIX environment variables
- Implement interactive path selection and tilde expansion in 'zb init'
- Update install.sh to handle piped interactive input and delegate config to the CLI
- Improve 'zb reset' to handle custom paths and ensure clean re-initialization

Written by Claude Opus 4.5.
Works great for me 😀