### PR TITLE
chore(changelog): introduce changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to zerobrew will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - TBD
+
+Initial release of zerobrew - a fast, modern package manager. We're excited for our pilot release and 
+want to thank all of the support from all channels, as well as all of our contributors up to this point. 
+
+To get an idea of the initial features zerobrew supports, take a look at the [README](https://github.com/lucasgelfond/zerobrew#readme).
+
+See the [full commit history](https://github.com/lucasgelfond/zerobrew/commits/v0.1.0) for more details.
+
+[Unreleased]: https://github.com/lucasgelfond/zerobrew/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/lucasgelfond/zerobrew/releases/tag/v0.1.0


### PR DESCRIPTION
Introduced our changelog.

Initial release shouldn't have any in-depth notes about features, we can just link them to the README.

~~We should not merge this until we develop a roadmap, @maria-rcks @lucasgelfond we can talk about that internally.~~
Roadmap will come down the line
