### PR TITLE
fix: real human-readable install timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +104,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
@@ -180,6 +195,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -790,6 +818,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1148,15 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -2236,10 +2297,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2553,6 +2667,7 @@ dependencies = [
 name = "zb_cli"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "clap_complete",
  "console",

--- a/zb_cli/Cargo.toml
+++ b/zb_cli/Cargo.toml
@@ -15,6 +15,7 @@ serde_json.workspace = true
 
 zb_core = { path = "../zb_core" }
 zb_io = { path = "../zb_io" }
+chrono = "0.4.43"
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/zb_cli/src/commands/info.rs
+++ b/zb_cli/src/commands/info.rs
@@ -1,19 +1,15 @@
+use chrono::{DateTime, Local};
 use console::style;
-use std::time::{Duration, UNIX_EPOCH};
 
 pub fn execute(
     installer: &mut zb_io::install::Installer,
     formula: String,
 ) -> Result<(), zb_core::Error> {
     if let Some(keg) = installer.get_installed(&formula) {
-        println!("{}       {}", style("Name:").dim(), style(&keg.name).bold());
-        println!("{}    {}", style("Version:").dim(), keg.version);
-        println!("{}  {}", style("Store key:").dim(), &keg.store_key[..12]);
-        println!(
-            "{}  {}",
-            style("Installed:").dim(),
-            format_timestamp(keg.installed_at)
-        );
+        print_field("Name:", style(&keg.name).bold());
+        print_field("Version:", &keg.version);
+        print_field("Store key:", &keg.store_key[..12]);
+        print_field("Installed:", format_timestamp(keg.installed_at));
     } else {
         println!("Formula '{}' is not installed.", formula);
     }
@@ -21,12 +17,37 @@ pub fn execute(
     Ok(())
 }
 
-fn format_timestamp(timestamp: i64) -> String {
-    let secs = timestamp.max(0) as u64;
-    let dt = UNIX_EPOCH + Duration::from_secs(secs);
+fn print_field(label: &str, value: impl std::fmt::Display) {
+    println!("{:<10}  {}", style(label).dim(), value);
+}
 
-    match dt.duration_since(UNIX_EPOCH) {
-        Ok(dur) => format!("{}s since epoch", dur.as_secs()),
-        Err(_) => "invalid timestamp".to_string(),
+fn format_timestamp(timestamp: i64) -> String {
+    match DateTime::from_timestamp(timestamp, 0) {
+        Some(dt) => {
+            let local_dt = dt.with_timezone(&Local);
+            let now = Local::now();
+            let duration = now.signed_duration_since(local_dt);
+
+            if duration.num_days() > 0 {
+                format!(
+                    "{} ({} days ago)",
+                    local_dt.format("%Y-%m-%d"),
+                    duration.num_days()
+                )
+            } else if duration.num_hours() > 0 {
+                format!(
+                    "{} ({} hours ago)",
+                    local_dt.format("%Y-%m-%d %H:%M"),
+                    duration.num_hours()
+                )
+            } else {
+                format!(
+                    "{} ({} minutes ago)",
+                    local_dt.format("%H:%M"),
+                    duration.num_minutes()
+                )
+            }
+        }
+        None => "invalid timestamp".to_string(),
     }
 }


### PR DESCRIPTION
This PR mainly addresses issues with the `info` command:
1. The original `Installed` field outputs a unix timestamp, which is not really human-readable.
2. The original `format_timestamp` function to generate the timestamp mentioned above has significant logic flaws.

This PR also introduces a small `print_field` helper function to better control field alignment to a fixed width.