### PR TITLE
fix(zb_cli): don't modify user's shell config (PATH) at runtime

### DIFF
--- a/zb_cli/src/commands/init.rs
+++ b/zb_cli/src/commands/init.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use crate::init::{InitError, run_init_with_shell_setup};
+use crate::init::{InitError, run_init};
 
 pub fn execute(root: &Path, prefix: &Path) -> Result<(), zb_core::Error> {
-    run_init_with_shell_setup(root, prefix).map_err(|e| match e {
+    run_init(root, prefix).map_err(|e| match e {
         InitError::Message(msg) => zb_core::Error::StoreCorruption { message: msg },
     })
 }


### PR DESCRIPTION
This currently happens both on every command (via `ensure_init`) as well as in the initial install. This has some issues:

* It violates the principle of least surprise -- the user generally only wants explicit installer/uninstaller scripts to modify shell configs. A package manager modifying user dotfiles at runtime is an anti-pattern overall.

* The duplicated logic could diverge and cause inconsistencies. The uninstall procedure in the Justfile (`_clean_shell_config)` expects the format written by install.sh, for example.

Instead, we leave the installer to handle this and we can warn the user at runtime if $prefix/bin isn't in their PATH.

This change follows on from https://github.com/lucasgelfond/zerobrew/commit/a9ef4e3c21a8a25ab79e55b83dc9a71025a7e79f. See also d548aeb, the initial `add_to_path` implementation.