### PR TITLE
refactor(install.sh): better install / onboarding

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,11 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -euo pipefail
 
-# zerobrew installer
-# Usage: curl -sSL https://raw.githubusercontent.com/lucasgelfond/zerobrew/main/install.sh | bash
+# Restore cursor on exit
+restore_cursor() {
+    printf '\033[?25h'
+}
+trap restore_cursor EXIT
 
 ZEROBREW_REPO="https://github.com/lucasgelfond/zerobrew.git"
 : ${ZEROBREW_DIR:=$HOME/.zerobrew}
@@ -17,148 +20,275 @@ else
     ZEROBREW_ROOT="$XDG_DATA_HOME/zerobrew"
 fi
 
-export ZEROBREW_ROOT
-
 # Allow custom prefix, default to $ZEROBREW_ROOT/prefix
 : ${ZEROBREW_PREFIX:=$ZEROBREW_ROOT/prefix}
+
+export ZEROBREW_ROOT
 export ZEROBREW_PREFIX
 
 # Prevent running with sudo - the script handles its own privilege escalation
 if [[ $EUID -eq 0 ]]; then
-    echo "Error: Do not run this script with sudo or as root."
-    echo "The installer will automatically request privileges when needed."
-    exit 1
+    error_exit "Do not run this script with sudo or as root. The installer will automatically request privileges when needed."
 fi
 
-echo "Installing zerobrew..."
+no_modify_path=false
+binary_paths=()
+
+MUTED=$'\033[0;2m'
+RED=$'\033[0;31m'
+ORANGE=$'\033[38;5;214m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+usage() {
+    printf "zero%bbrew%b Installer\n" "$ORANGE" "$NC"
+    printf "\n"
+    printf "Usage: install.sh %b[options]%b\n" "$MUTED" "$NC"
+    printf "\n"
+    printf "Options:\n"
+    printf "    -h, --help               %bDisplay this help message%b\n" "$MUTED" "$NC"
+    printf "    -b, --binary <path>...   %bInstalls binaries (zb, zbx) to \$ZEROBREW_BIN%b\n" "$MUTED" "$NC"
+    printf "        --no-modify-path     %bDon't modify shell config files (.zshrc, .bashrc, etc.)%b\n" "$MUTED" "$NC"
+    printf "\n"
+    printf "Examples:%b\n" "$MUTED"
+    printf "    ./install.sh --no-modify-path\n"
+    printf "    ./install.sh -b /path/to/zb\n"
+    printf "    ./install.sh -b /path/to/zb /path/to/zbx%b\n" "$NC"
+}
+
+spinner() {
+    local msg="$1"
+    local pid=$2
+    local spin='|/-\'
+    local i=0
+    local exit_code=0
+
+    printf '\033[?25l'
+
+    while kill -0 $pid 2>/dev/null; do
+        i=$(((i + 1) % 4))
+        printf "\r%b[%s]%b %b" "$ORANGE" "${spin:$i:1}" "$NC" "$msg"
+        sleep 0.1
+    done
+
+    wait $pid 2>/dev/null && exit_code=0 || exit_code=$?
+
+    printf "\r\033[K"
+    printf '\033[?25h'
+
+    return $exit_code
+}
+
+completed() {
+    printf "%b[✓]%b %b\n" "$GREEN" "$NC" "$1"
+}
+
+error_exit() {
+    local msg="$1"
+    local exit_code="${2:-1}"
+    printf "\r\033[K"
+    printf '\033[?25h'
+    printf "%b[✗]%b %b\n" "$RED" "$NC" "$msg" >&2
+    exit $exit_code
+}
+
+check_command() {
+    local cmd="$1"
+    local install_hint="${2:-}"
+
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        local msg="Required command '$cmd' not found"
+        if [[ -n "$install_hint" ]]; then
+            msg="$msg. Hint: $install_hint"
+        fi
+        error_exit "$msg"
+    fi
+}
+
+install_bin() {
+    local target_dir="$1"
+    shift
+    local paths_to_install=("$@")
+
+    if ! mkdir -p "$target_dir"; then
+        error_exit "Failed to create directory: $target_dir"
+    fi
+
+    for binary_path in "${paths_to_install[@]}"; do
+        if [[ ! -f "$binary_path" ]]; then
+            error_exit "Binary not found at ${binary_path}"
+        fi
+
+        local binary_name
+        binary_name=$(basename "$binary_path")
+
+        if ! install -Dm755 "$binary_path" "$target_dir/$binary_name"; then
+            error_exit "Failed to copy $binary_name to $target_dir"
+        fi
+
+        completed "Installed ${ORANGE}$binary_name${NC} to $target_dir"
+    done
+}
+
+zb_init() {
+    local zb_path="$1"
+    local no_modify="$2"
+    local init_args=()
+
+    if [[ "$no_modify" == "true" ]]; then
+        init_args+=("--no-modify-path")
+    fi
+
+    "$zb_path" init "${init_args[@]}" >/dev/null 2>&1 || error_exit "Failed to initialize zerobrew"
+}
+
+print_logo() {
+    printf "\n"
+    printf "%b▄▄▄▄▄ ▄▄▄▄▄ ▄▄▄▄   ▄▄▄ %b ▄▄▄▄  ▄▄▄▄  ▄▄▄▄▄ ▄▄   ▄▄\n" "$NC" "$ORANGE"
+    printf "%b  ▄█▀ ██▄▄  ██▄█▄ ██▀██%b ██▄██ ██▄█▄ ██▄▄  ██ ▄ ██\n" "$NC" "$ORANGE"
+    printf "%b▄██▄▄ ██▄▄▄ ██ ██ ▀███▀%b ██▄█▀ ██ ██ ██▄▄▄  ▀█▀█▀ \n" "$NC" "$ORANGE"
+    printf "\n"
+
+    printf "%bStart installing %bPackages%b with %bzerobrew%b:\n\n" "$MUTED" "$NC" "$MUTED" "$ORANGE" "$NC"
+    printf "  zb install %bffmpeg%b    # Install a Package%b\n" "$ORANGE" "$MUTED" "$NC"
+    printf "  zbx %byetris%b           # Single-time Run\n\n" "$ORANGE" "$MUTED" "$NC"
+    printf "%bFor more information visit %bhttps://zerobrew.rs/docs\n\n" "$MUTED" "$NC"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    --no-modify-path)
+        no_modify_path=true
+        shift
+        ;;
+    -b | --binary)
+        if [[ -n "${2:-}" ]]; then
+            binary_paths+=("$2")
+            shift 2
+            if [[ -n "${1:-}" && "${1:0:1}" != "-" ]]; then
+                binary_paths+=("$1")
+                shift
+            fi
+        else
+            error_exit "--binary requires a path argument"
+        fi
+        ;;
+    *)
+        error_exit "Unknown option '%s'" "$1"
+        ;;
+    esac
+done
+
+# Skip all if binary path is provided
+if [[ ${#binary_paths[@]} -gt 0 ]]; then
+    install_bin "$ZEROBREW_BIN" "${binary_paths[@]}"
+
+    zb_init "$ZEROBREW_BIN/zb" "$no_modify_path"
+
+    print_logo
+    completed "Installation complete"
+    exit 0
+fi
+
+# Check for required commands
+check_command "curl" "Install curl using your package manager (e.g., 'brew install curl' on macOS)"
+check_command "git" "Install git using your package manager (e.g., 'brew install git' on macOS)"
+check_command "mkdir" "Your system should have mkdir installed by default"
+check_command "cp" "Your system should have cp installed by default"
+check_command "chmod" "Your system should have chmod installed by default"
 
 # Check for Rust/Cargo
-if ! command -v cargo &> /dev/null; then
-    echo "Rust not found. Installing via rustup..."
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+if ! command -v cargo >/dev/null 2>&1; then
+    (
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    ) &
+    if ! spinner "Installing ${ORANGE}Rust toolchain${NC}" $!; then
+        error_exit "Failed to install Rust toolchain. Check your network connection and try again."
+    fi
+    # shellcheck source=/dev/null
     source "$HOME/.cargo/env"
+    completed "${ORANGE}Rust toolchain${NC} installed"
 fi
 
 # Ensure cargo is available
-if ! command -v cargo &> /dev/null; then
-    echo "Error: Cargo still not found after installing Rust"
-    exit 1
+if ! command -v cargo >/dev/null 2>&1; then
+    error_exit "Cargo not found after installing Rust. Try restarting your terminal or running: source ~/.cargo/env"
 fi
-
-echo "Rust version: $(rustc --version)"
 
 # Clone or update repo
 if [[ -d "$ZEROBREW_DIR" ]]; then
-    echo "Updating zerobrew..."
-    cd "$ZEROBREW_DIR"
-    git fetch --depth=1 origin main
-    git reset --hard origin/main
+    (
+        cd "$ZEROBREW_DIR" || exit 1
+        if ! git fetch --depth=1 origin main >/dev/null 2>&1; then
+            printf "Failed to fetch updates\n" >&2
+            exit 1
+        fi
+        if ! git reset --hard origin/main >/dev/null 2>&1; then
+            printf "Failed to reset to origin/main\n" >&2
+            exit 1
+        fi
+    ) &
+    if ! spinner "Updating ${ORANGE}zerobrew${NC} repository" $!; then
+        error_exit "Failed to update zerobrew repository. Check your network connection and permissions."
+    fi
+    completed "Updated ${ORANGE}zerobrew${NC} repository"
+    cd "$ZEROBREW_DIR" || error_exit "Failed to enter directory: $ZEROBREW_DIR"
 else
-    echo "Cloning zerobrew..."
-    git clone --depth 1 "$ZEROBREW_REPO" "$ZEROBREW_DIR"
-    cd "$ZEROBREW_DIR"
+    (
+        if ! git clone --depth 1 "$ZEROBREW_REPO" "$ZEROBREW_DIR" >/dev/null 2>&1; then
+            printf "Failed to clone repository\n" >&2
+            exit 1
+        fi
+    ) &
+    if ! spinner "Cloning ${ORANGE}zerobrew${NC} repository" $!; then
+        error_exit "Failed to clone zerobrew repository. Check your network connection and that the repository exists."
+    fi
+    completed "Cloned ${ORANGE}zerobrew${NC} repository"
+    cd "$ZEROBREW_DIR" || error_exit "Failed to enter directory: $ZEROBREW_DIR"
 fi
 
 # Build
-echo "Building zerobrew..."
 if [[ -d "$ZEROBREW_PREFIX/lib/pkgconfig" ]]; then
     export PKG_CONFIG_PATH="$ZEROBREW_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 fi
 if [[ -d "/opt/homebrew/lib/pkgconfig" ]] && [[ ! "$PKG_CONFIG_PATH" =~ "/opt/homebrew/lib/pkgconfig" ]]; then
     export PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 fi
-cargo build --release
 
-# Create bin directory and install binary
-mkdir -p "$ZEROBREW_BIN"
-cp target/release/zb "$ZEROBREW_BIN/zb"
-chmod +x "$ZEROBREW_BIN/zb"
-echo "Installed zb to $ZEROBREW_BIN/zb"
-
-# Detect shell config file
-case "$SHELL" in
-    */zsh)
-        ZDOTDIR="${ZDOTDIR:-$HOME}"
-        if [[ -f "$ZDOTDIR/.zshenv" ]]; then
-            SHELL_CONFIG="$ZDOTDIR/.zshenv"
-        else
-            SHELL_CONFIG="$ZDOTDIR/.zshrc"
-        fi
-        ;;
-    */bash)
-        if [[ -f "$HOME/.bash_profile" ]]; then
-            SHELL_CONFIG="$HOME/.bash_profile"
-        else
-            SHELL_CONFIG="$HOME/.bashrc"
-        fi
-        ;;
-    *)
-        SHELL_CONFIG="$HOME/.profile"
-        ;;
-esac
-
-if [[ ! -w $SHELL_CONFIG ]]; then
-    echo "Error, config not writable: $SHELL_CONFIG" >&2
-    exit 1
-fi
-
-# Add to PATH in shell config if not already there
-PATHS_TO_ADD=("\$ZEROBREW_BIN" "\$ZEROBREW_PREFIX/bin")
-if ! grep -q "^# zerobrew$" "$SHELL_CONFIG" 2>/dev/null; then
-    cat >>"$SHELL_CONFIG" <<EOF
-# zerobrew
-export ZEROBREW_DIR=$ZEROBREW_DIR
-export ZEROBREW_BIN=$ZEROBREW_BIN
-export ZEROBREW_ROOT=$ZEROBREW_ROOT
-export ZEROBREW_PREFIX=$ZEROBREW_PREFIX
-export PKG_CONFIG_PATH="$ZEROBREW_PREFIX/lib/pkgconfig:\${PKG_CONFIG_PATH:-}"
-_zb_path_append() {
-    local argpath="\$1"
-    case ":\${PATH}:" in
-        *:"\$argpath":*) ;;
-        *) export PATH="\$argpath:\$PATH" ;;
-    esac;
-}
-EOF
-    for path_entry in "${PATHS_TO_ADD[@]}"; do
-        if ! grep -q "$path_entry" "$SHELL_CONFIG" 2>/dev/null; then
-            echo "_zb_path_append $path_entry" >>"$SHELL_CONFIG"
-            echo "Added $path_entry to PATH in $SHELL_CONFIG"
-        fi
-    done
-fi
-
-# Export for current session so zb init works
-export PATH="$ZEROBREW_BIN:$ZEROBREW_PREFIX/bin:$PATH"
-
-# Set up zerobrew directories (zb init will handle the details)
-echo ""
-echo "Setting up zerobrew directories at $ZEROBREW_ROOT..."
-
-# Only need sudo for /opt paths on macOS
-if [[ "$ZEROBREW_ROOT" == /opt/* ]]; then
-    if [[ ! -d "$ZEROBREW_ROOT" ]] || [[ ! -w "$ZEROBREW_ROOT" ]]; then
-        echo "Creating $ZEROBREW_ROOT (requires sudo)..."
-        sudo mkdir -p "$ZEROBREW_ROOT"
-        sudo chown -R "$(whoami)" "$ZEROBREW_ROOT"
+(
+    if ! cargo build --release --bin zb --bin zbx >/dev/null 2>&1; then
+        error_exit "Build failed. Run 'cargo build --bin zb --bin zbx' to see details."
     fi
+) &
+if ! spinner "Building ${ORANGE}zerobrew${NC}" $!; then
+    error_exit "Failed to build zerobrew. Ensure Rust and dependencies are properly installed."
+fi
+completed "Built ${ORANGE}zerobrew${NC}"
+
+if [[ ! -f "target/release/zb" ]]; then
+    error_exit "Build succeeded but zb binary not found at target/release/zb"
 fi
 
-# Run zb init to finalize setup
-echo ""
-echo "Running zb init..."
-"$ZEROBREW_BIN/zb" init
+if [[ ! -f "target/release/zbx" ]]; then
+    error_exit "Build succeeded but zbx binary not found at target/release/zbx"
+fi
 
-echo ""
-echo "============================================"
-echo "  zerobrew installed successfully!"
-echo "============================================"
-echo ""
-echo "Run this to start using zerobrew now:"
-echo ""
-echo "    export PATH=\"$ZEROBREW_BIN:$ZEROBREW_PREFIX/bin:\$PATH\""
-echo ""
-echo "Or restart your terminal, to source updated ${SHELL_CONFIG}."
-echo ""
-echo "Then try: zb install ffmpeg"
-echo ""
+install_bin "$ZEROBREW_BIN" target/release/zb target/release/zbx
+
+# Verify the binary works
+if ! "$ZEROBREW_BIN/zb" --version >/dev/null 2>&1; then
+    error_exit "Installation succeeded but binary does not execute properly"
+fi
+
+# Add zb to PATH for current session if not already present
+if [[ ":$PATH:" != *":$ZEROBREW_BIN:"* ]]; then
+    export PATH="$ZEROBREW_BIN:$PATH"
+fi
+
+zb_init "$ZEROBREW_BIN/zb" "$no_modify_path"
+
+print_logo

--- a/zb_cli/src/bin/zb.rs
+++ b/zb_cli/src/bin/zb.rs
@@ -26,8 +26,8 @@ async fn run(cli: Cli) -> Result<(), zb_core::Error> {
     let root = get_root_path(cli.root);
     let prefix = cli.prefix.unwrap_or_else(|| root.join("prefix"));
 
-    if matches!(cli.command, Commands::Init) {
-        return commands::init::execute(&root, &prefix);
+    if let Commands::Init { no_modify_path } = cli.command {
+        return commands::init::execute(&root, &prefix, no_modify_path);
     }
 
     if !matches!(cli.command, Commands::Reset { .. }) {
@@ -37,7 +37,7 @@ async fn run(cli: Cli) -> Result<(), zb_core::Error> {
     let mut installer = create_installer(&root, &prefix, cli.concurrency)?;
 
     match cli.command {
-        Commands::Init => unreachable!(),
+        Commands::Init { .. } => unreachable!(),
         Commands::Completion { .. } => unreachable!(),
         Commands::Install { formulas, no_link } => {
             commands::install::execute(&mut installer, formulas, no_link).await

--- a/zb_cli/src/cli.rs
+++ b/zb_cli/src/cli.rs
@@ -54,7 +54,10 @@ pub enum Commands {
         #[arg(long, short = 'y')]
         yes: bool,
     },
-    Init,
+    Init {
+        #[arg(long)]
+        no_modify_path: bool,
+    },
     Completion {
         #[arg(value_enum)]
         shell: clap_complete::shells::Shell,

--- a/zb_cli/src/commands/init.rs
+++ b/zb_cli/src/commands/init.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use crate::init::{InitError, run_init};
 
-pub fn execute(root: &Path, prefix: &Path) -> Result<(), zb_core::Error> {
-    run_init(root, prefix).map_err(|e| match e {
+pub fn execute(root: &Path, prefix: &Path, no_modify_path: bool) -> Result<(), zb_core::Error> {
+    run_init(root, prefix, no_modify_path).map_err(|e| match e {
         InitError::Message(msg) => zb_core::Error::StoreCorruption { message: msg },
     })
 }

--- a/zb_cli/src/commands/reset.rs
+++ b/zb_cli/src/commands/reset.rs
@@ -56,7 +56,8 @@ pub fn execute(root: &Path, prefix: &Path, yes: bool) -> Result<(), zb_core::Err
         }
     }
 
-    run_init(root, prefix).map_err(|e| match e {
+    // Pass false for no_modify_shell since this is a re-initialization
+    run_init(root, prefix, false).map_err(|e| match e {
         InitError::Message(msg) => zb_core::Error::StoreCorruption { message: msg },
     })?;
 

--- a/zb_cli/src/init.rs
+++ b/zb_cli/src/init.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[derive(Debug)]
 pub enum InitError {
     Message(String),
 }
@@ -27,8 +28,18 @@ pub fn is_writable(path: &Path) -> bool {
     }
 }
 
-pub fn run_init(root: &Path, prefix: &Path) -> Result<(), InitError> {
+pub fn run_init(root: &Path, prefix: &Path, no_modify_path: bool) -> Result<(), InitError> {
     println!("{} Initializing zerobrew...", style("==>").cyan().bold());
+
+    let zerobrew_dir = match std::env::var("ZEROBREW_DIR") {
+        Ok(dir) => dir,
+        Err(_) => {
+            let home = std::env::var("HOME")
+                .map_err(|_| InitError::Message("HOME not set".to_string()))?;
+            format!("{}/.zerobrew", home)
+        }
+    };
+    let zerobrew_bin = format!("{}/bin", zerobrew_dir);
 
     let dirs_to_create: Vec<PathBuf> = vec![
         root.to_path_buf(),
@@ -109,17 +120,124 @@ pub fn run_init(root: &Path, prefix: &Path) -> Result<(), InitError> {
         }
     }
 
-    let bin_path = prefix.join("bin");
-    let current_path = std::env::var("PATH").unwrap_or_default();
-    if !current_path.contains(&bin_path.to_string_lossy().to_string()) {
-        println!(
-            "    {} Add {} to your PATH, or re-run the installer",
-            style("→").cyan(),
-            style(bin_path.display()).cyan()
-        );
-    }
+    add_to_path(prefix, &zerobrew_dir, &zerobrew_bin, root, no_modify_path)?;
 
     println!("{} Initialization complete!", style("==>").cyan().bold());
+
+    Ok(())
+}
+
+fn add_to_path(
+    prefix: &Path,
+    zerobrew_dir: &str,
+    zerobrew_bin: &str,
+    root: &Path,
+    no_modify_path: bool,
+) -> Result<(), InitError> {
+    let shell = std::env::var("SHELL").unwrap_or_default();
+    let home = std::env::var("HOME").map_err(|_| InitError::Message("HOME not set".to_string()))?;
+
+    let config_file = if shell.contains("zsh") {
+        let zdotdir = std::env::var("ZDOTDIR").unwrap_or_else(|_| home.clone());
+        let zshenv = format!("{}/.zshenv", zdotdir);
+
+        if std::path::Path::new(&zshenv).exists() {
+            zshenv
+        } else {
+            format!("{}/.zshrc", zdotdir)
+        }
+    } else if shell.contains("bash") {
+        let bash_profile = format!("{}/.bash_profile", home);
+        if std::path::Path::new(&bash_profile).exists() {
+            bash_profile
+        } else {
+            format!("{}/.bashrc", home)
+        }
+    } else {
+        format!("{}/.profile", home)
+    };
+
+    let prefix_bin = prefix.join("bin");
+
+    // Check if zerobrew is already configured
+    let already_added = if let Ok(contents) = std::fs::read_to_string(&config_file) {
+        contents.contains("# zerobrew")
+    } else {
+        false
+    };
+
+    if !no_modify_path && !already_added {
+        // Build the shell configuration content
+        let config_content = format!(
+            "\n# zerobrew
+export ZEROBREW_DIR={}
+export ZEROBREW_BIN={}
+export ZEROBREW_ROOT={}
+export ZEROBREW_PREFIX={}
+export PKG_CONFIG_PATH=\"{}/lib/pkgconfig:${{PKG_CONFIG_PATH:-}}\"
+_zb_path_append() {{
+    local argpath=\"$1\"
+    case \":${{PATH}}:\" in
+        *:\"$argpath\":*) ;;
+        *) export PATH=\"$argpath:$PATH\" ;;
+    esac;
+}}
+_zb_path_append {}
+_zb_path_append {}
+",
+            zerobrew_dir,
+            zerobrew_bin,
+            root.display(),
+            prefix.display(),
+            prefix.display(),
+            zerobrew_bin,
+            prefix_bin.display()
+        );
+
+        let write_result = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&config_file)
+            .and_then(|mut f| f.write_all(config_content.as_bytes()));
+
+        if let Err(e) = write_result {
+            println!(
+                "{} Could not write to {} due to error: {}",
+                style("Warning:").yellow().bold(),
+                config_file,
+                e
+            );
+            println!(
+                "{} Please add the following to {}:",
+                style("Info:").cyan().bold(),
+                config_file
+            );
+            println!("{}", config_content);
+        } else {
+            println!(
+                "    {} Added zerobrew configuration to {}",
+                style("✓").green(),
+                config_file
+            );
+            println!(
+                "    {} Added {} and {} to PATH",
+                style("✓").green(),
+                zerobrew_bin,
+                prefix_bin.display()
+            );
+        }
+    } else if no_modify_path {
+        println!(
+            "    {} Skipped shell configuration (--no-modify-path)",
+            style("→").cyan()
+        );
+        println!(
+            "    {} To use zerobrew, add {} and {} to your PATH",
+            style("→").cyan(),
+            zerobrew_bin,
+            prefix_bin.display()
+        );
+    }
 
     Ok(())
 }
@@ -151,7 +269,392 @@ pub fn ensure_init(root: &Path, prefix: &Path) -> Result<(), zb_core::Error> {
         });
     }
 
-    run_init(root, prefix).map_err(|e| match e {
+    // Pass false for no_modify_shell since user confirmed they want full initialization
+    run_init(root, prefix, false).map_err(|e| match e {
         InitError::Message(msg) => zb_core::Error::StoreCorruption { message: msg },
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    #[test]
+    fn needs_init_when_directories_missing() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("nonexistent_root");
+        let prefix = tmp.path().join("nonexistent_prefix");
+
+        assert!(needs_init(&root, &prefix));
+    }
+
+    #[test]
+    fn needs_init_when_not_writable() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("root");
+        let prefix = tmp.path().join("prefix");
+
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&prefix).unwrap();
+
+        // Make directories read-only
+        let mut root_perms = fs::metadata(&root).unwrap().permissions();
+        root_perms.set_mode(0o555);
+        fs::set_permissions(&root, root_perms).unwrap();
+
+        let result = needs_init(&root, &prefix);
+
+        // Restore permissions for cleanup
+        let mut root_perms = fs::metadata(&root).unwrap().permissions();
+        root_perms.set_mode(0o755);
+        fs::set_permissions(&root, root_perms).unwrap();
+
+        assert!(result);
+    }
+
+    #[test]
+    fn no_init_needed_when_writable() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("root");
+        let prefix = tmp.path().join("prefix");
+
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&prefix).unwrap();
+
+        assert!(!needs_init(&root, &prefix));
+    }
+
+    #[test]
+    fn is_writable_returns_true_for_writable_dir() {
+        let tmp = TempDir::new().unwrap();
+        assert!(is_writable(tmp.path()));
+    }
+
+    #[test]
+    fn is_writable_returns_false_for_nonexistent_path() {
+        let tmp = TempDir::new().unwrap();
+        let nonexistent = tmp.path().join("does_not_exist");
+        assert!(!is_writable(&nonexistent));
+    }
+
+    #[test]
+    fn is_writable_returns_false_for_readonly_dir() {
+        let tmp = TempDir::new().unwrap();
+        let readonly = tmp.path().join("readonly");
+        fs::create_dir(&readonly).unwrap();
+
+        let mut perms = fs::metadata(&readonly).unwrap().permissions();
+        perms.set_mode(0o555);
+        fs::set_permissions(&readonly, perms).unwrap();
+
+        assert!(!is_writable(&readonly));
+
+        // Restore permissions for cleanup
+        let mut perms = fs::metadata(&readonly).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&readonly, perms).unwrap();
+    }
+
+    #[test]
+    fn add_to_path_writes_all_env_vars() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let shell_config = home.join(".bashrc");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        // Set up environment to simulate bash
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+        }
+        unsafe {
+            std::env::set_var("SHELL", "/bin/bash");
+        }
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, false).unwrap();
+
+        let content = fs::read_to_string(&shell_config).unwrap();
+        assert!(content.contains("export ZEROBREW_DIR=/home/user/.zerobrew"));
+        assert!(content.contains("export ZEROBREW_BIN=/home/user/.zerobrew/bin"));
+        assert!(content.contains(&format!("export ZEROBREW_ROOT={}", root.display())));
+        assert!(content.contains(&format!("export ZEROBREW_PREFIX={}", prefix.display())));
+        assert!(content.contains("export PKG_CONFIG_PATH="));
+        assert!(content.contains("/lib/pkgconfig"));
+    }
+
+    #[test]
+    fn add_to_path_includes_path_append_function() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let shell_config = home.join(".bashrc");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+        }
+        unsafe {
+            std::env::set_var("SHELL", "/bin/bash");
+        }
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, false).unwrap();
+
+        let content = fs::read_to_string(&shell_config).unwrap();
+        assert!(content.contains("_zb_path_append()"));
+        assert!(content.contains("case \":${PATH}:"));
+        assert!(content.contains("_zb_path_append"));
+    }
+
+    #[test]
+    fn add_to_path_adds_both_paths() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let shell_config = home.join(".bashrc");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+        }
+        unsafe {
+            std::env::set_var("SHELL", "/bin/bash");
+        }
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, false).unwrap();
+
+        let content = fs::read_to_string(&shell_config).unwrap();
+        // Both paths should be added via _zb_path_append
+        assert!(content.contains("_zb_path_append /home/user/.zerobrew/bin"));
+        assert!(content.contains(&format!("_zb_path_append {}", prefix.join("bin").display())));
+    }
+
+    #[test]
+    fn add_to_path_no_modify_shell_skips_write() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let shell_config = home.join(".bashrc");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+        }
+        unsafe {
+            std::env::set_var("SHELL", "/bin/bash");
+        }
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, true).unwrap();
+
+        // File should not be created
+        assert!(!shell_config.exists());
+    }
+
+    #[test]
+    fn add_to_path_no_duplicate_config() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let shell_config = home.join(".bashrc");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+        }
+        unsafe {
+            std::env::set_var("SHELL", "/bin/bash");
+        }
+
+        // Write initial config
+        fs::write(&shell_config, "# existing content\n# zerobrew\n").unwrap();
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, false).unwrap();
+
+        // Content should remain unchanged since # zerobrew already exists
+        let content = fs::read_to_string(&shell_config).unwrap();
+        assert!(!content.contains("export ZEROBREW_DIR"));
+        assert_eq!(content, "# existing content\n# zerobrew\n");
+    }
+
+    #[test]
+    fn add_to_path_uses_zshrc_for_zsh() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let shell_config = home.join(".zshrc");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+            std::env::set_var("SHELL", "/bin/zsh");
+            std::env::remove_var("ZDOTDIR");
+        }
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, false).unwrap();
+
+        assert!(shell_config.exists());
+        let content = fs::read_to_string(&shell_config).unwrap();
+        assert!(content.contains("# zerobrew"));
+    }
+
+    #[test]
+    fn add_to_path_prefers_zshenv_when_exists() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let zshenv = home.join(".zshenv");
+        let zshrc = home.join(".zshrc");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        // Create .zshenv first
+        fs::write(&zshenv, "# existing zshenv\n").unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+        }
+        unsafe {
+            std::env::set_var("SHELL", "/bin/zsh");
+        }
+        unsafe {
+            std::env::remove_var("ZDOTDIR");
+        }
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, false).unwrap();
+
+        // Should write to .zshenv, not .zshrc
+        assert!(zshenv.exists());
+        let zshenv_content = fs::read_to_string(&zshenv).unwrap();
+        assert!(zshenv_content.contains("# zerobrew"));
+        assert!(!zshrc.exists());
+    }
+
+    #[test]
+    fn add_to_path_uses_bash_profile_when_exists() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let bash_profile = home.join(".bash_profile");
+        let bashrc = home.join(".bashrc");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        // Create .bash_profile first
+        fs::write(&bash_profile, "# existing bash_profile\n").unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+        }
+        unsafe {
+            std::env::set_var("SHELL", "/bin/bash");
+        }
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, false).unwrap();
+
+        // Should write to .bash_profile, not .bashrc
+        assert!(bash_profile.exists());
+        let profile_content = fs::read_to_string(&bash_profile).unwrap();
+        assert!(profile_content.contains("# zerobrew"));
+        assert!(!bashrc.exists());
+    }
+
+    #[test]
+    fn add_to_path_uses_profile_for_other_shells() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let profile = home.join(".profile");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+        }
+        unsafe {
+            std::env::set_var("SHELL", "/bin/fish");
+        }
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, false).unwrap();
+
+        assert!(profile.exists());
+        let content = fs::read_to_string(&profile).unwrap();
+        assert!(content.contains("# zerobrew"));
+    }
+
+    #[test]
+    fn add_to_path_uses_zdotdir_when_set() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        let zdotdir = tmp.path().join("zsh_config");
+        let prefix = tmp.path().join("prefix");
+        let root = tmp.path().join("root");
+        let shell_config = zdotdir.join(".zshrc");
+        let zerobrew_dir = "/home/user/.zerobrew";
+        let zerobrew_bin = "/home/user/.zerobrew/bin";
+
+        fs::create_dir(&zdotdir).unwrap();
+        fs::create_dir(&prefix).unwrap();
+        fs::create_dir(&root).unwrap();
+
+        unsafe {
+            std::env::set_var("HOME", home.to_str().unwrap());
+        }
+        unsafe {
+            std::env::set_var("SHELL", "/bin/zsh");
+        }
+        unsafe {
+            std::env::set_var("ZDOTDIR", zdotdir.to_str().unwrap());
+        }
+
+        add_to_path(&prefix, zerobrew_dir, zerobrew_bin, &root, false).unwrap();
+
+        // Should write to $ZDOTDIR/.zshrc
+        assert!(shell_config.exists());
+        let content = fs::read_to_string(&shell_config).unwrap();
+        assert!(content.contains("# zerobrew"));
+    }
 }


### PR DESCRIPTION
**changes:**
- refactors install.sh with proper error handling, colors, spinner animation, and better help output
- adds --no-modify-path and -b/--binary flags to install.sh
- moves shell config setup from install.sh to 'zb init' command
- adds --no-modify-path flag to 'zb init' to skip shell config modification
> AI-assisted: Planning and initial implementation with Kimi K2.5, manually reviewed and tested.

<img width="681" height="432" alt="image" src="https://github.com/user-attachments/assets/985e42e6-6d7a-4996-86e4-dfd5809a0a8a" />
