### PR TITLE
fix(zb_core): fix bottle selection to detect CPU arch on macOS

### DIFF
--- a/zb_core/fixtures/formula_foo.json
+++ b/zb_core/fixtures/formula_foo.json
@@ -11,6 +11,10 @@
           "url": "https://example.com/foo-1.2.3.arm64_sonoma.bottle.tar.gz",
           "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         },
+        "x86_64_sonoma": {
+          "url": "https://example.com/foo-1.2.3.x86_64_sonoma.bottle.tar.gz",
+          "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
         "x86_64_linux": {
           "url": "https://example.com/foo-1.2.3.x86_64_linux.bottle.tar.gz",
           "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"


### PR DESCRIPTION
Previously, bottle selection always chose ARM64 bottles on macOS regardless of the actual CPU architecture. This caused "Bad CPU type in executable" errors when running binaries on Intel Macs.

Now we use compile-time `target_arch` detection to select the correct bottles.

Fixes #78 