### PR TITLE
fix(install): allow unbound var in conditional

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -255,7 +255,7 @@ fi
 if [[ -d "$ZEROBREW_PREFIX/lib/pkgconfig" ]]; then
     export PKG_CONFIG_PATH="$ZEROBREW_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 fi
-if [[ -d "/opt/homebrew/lib/pkgconfig" ]] && [[ ! "$PKG_CONFIG_PATH" =~ "/opt/homebrew/lib/pkgconfig" ]]; then
+if [[ -d "/opt/homebrew/lib/pkgconfig" ]] && [[ ! "${PKG_CONFIG_PATH:-}" =~ "/opt/homebrew/lib/pkgconfig" ]]; then
     export PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
 fi
 


### PR DESCRIPTION
Commit 91208ac created an unbound variable when running the install.sh script on a fresh install.

This happens only when the environment does not already have a `PKG_CONFIG_PATH` defined.

By allowing the variable to not exist, this allows the install script to continue to install zerobrew.