### PR TITLE
fix(zb_cli): restore homebrew installation suggestion on install errors

### DIFF
--- a/zb_cli/src/utils.rs
+++ b/zb_cli/src/utils.rs
@@ -1,3 +1,4 @@
+use console::style;
 use std::path::PathBuf;
 
 pub fn normalize_formula_name(name: &str) -> Result<String, zb_core::Error> {
@@ -17,6 +18,22 @@ pub fn normalize_formula_name(name: &str) -> Result<String, zb_core::Error> {
     }
 
     Ok(trimmed.to_string())
+}
+
+pub fn suggest_homebrew(formula: &str, error: &zb_core::Error) {
+    eprintln!();
+    eprintln!(
+        "{} This package can't be installed with zerobrew.",
+        style("Note:").yellow().bold()
+    );
+    eprintln!("      Error: {}", error);
+    eprintln!();
+    eprintln!("      Try installing with Homebrew instead:");
+    eprintln!(
+        "      {}",
+        style(format!("brew install {}", formula)).cyan()
+    );
+    eprintln!();
 }
 
 pub fn get_root_path(cli_root: Option<PathBuf>) -> PathBuf {


### PR DESCRIPTION
A complete blunder on my part- when reviewing #129 I completely missed that the `suggest_homebrew` functionality on errors was removed.

Nothing broke, but I think that it's helpful to users and completely my fault that I let that removal slip through.
