### PR TITLE
fix(install): handle empty init_args array on bash 3.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ zb_init() {
         init_args+=("--no-modify-path")
     fi
 
-    "$zb_path" init "${init_args[@]}" >/dev/null 2>&1 || error_exit "Failed to initialize zerobrew"
+    "$zb_path" init ${init_args[@]+"${init_args[@]}"} >/dev/null 2>&1 || error_exit "Failed to initialize zerobrew"
 }
 
 print_logo() {


### PR DESCRIPTION
## Summary

Fixes "unbound variable" error when running install script on macOS with default bash 3.2.

## Problem

macOS ships with bash 3.2 (due to GPLv3 licensing), which has a quirk where expanding an empty array with `"${array[@]}"` triggers an "unbound variable" error even when the array is declared, when `set -u` is enabled.

```
bash: line 146: init_args[@]: unbound variable
```

This was fixed in bash 4.4+, but since the install script targets macOS users who likely have bash 3.2, we need to handle this case.

## Solution

Use the `${array[@]+"${array[@]}"}` pattern which safely expands to nothing when the array is empty/unset.

## Testing

- Tested on macOS with bash 3.2 - error no longer occurs
- The installation completes successfully including the `zb init` step