### PR TITLE
fix(install): empty `init_args` array on bash 3.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ zb_init() {
         init_args+=("--no-modify-path")
     fi
 
-    "$zb_path" init "${init_args[@]}" >/dev/null 2>&1 || error_exit "Failed to initialize zerobrew"
+    "$zb_path" init ${init_args[@]+"${init_args[@]}"} >/dev/null 2>&1 || error_exit "Failed to initialize zerobrew"
 }
 
 print_logo() {


### PR DESCRIPTION
Implementing change brought in by @shkm in #180.

Fixes #185

- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [X] I have disclosed in this PR if AI assistance was used to generate any code, documentation, or other contributions. I understand that if I do not adhere to this standard, my PR wil be closed, even without explanation.

No AI was used.
<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->


