### PR TITLE
Fix macOS relocation false positives for /usr/local and clean failed materializations

### DIFF
--- a/zb_io/src/installer/install.rs
+++ b/zb_io/src/installer/install.rs
@@ -307,6 +307,11 @@ impl Installer {
                     ) {
                         Ok(path) => path,
                         Err(e) => {
+                            Self::cleanup_materialized(
+                                &self.cellar,
+                                &processed_name,
+                                &processed_version,
+                            );
                             error = Some(e);
                             continue;
                         }


### PR DESCRIPTION
## Summary
- avoid Mach-O relocation false positives from generic `/usr/local` strings (for example `/usr/local/include` or CUDA hints)
- keep `/usr/local` relocation checks for Homebrew-owned paths (`/usr/local/opt`, `/usr/local/Cellar`, `/usr/local/Homebrew`)
- make the relocation error report the formula-specific max prefix length (from the matched old prefix) instead of a hardcoded value
- remove partially materialized kegs when `materialize()` fails so retries do not incorrectly succeed from stale contents

## Why
Installing `zig` could fail via `llvm@20` with:
- `prefix ... longer than /usr/local (10 bytes)`

That was triggered by non-relocatable generic defaults embedded in Mach-O binaries, not necessarily Homebrew-owned paths. The previous matcher was too broad.

## Validation
- `cargo +1.90.0 nextest run`
- fresh long-prefix install check now succeeds for `zig`/`llvm@20`
- repeated failing install now fails consistently instead of succeeding from a stale partial keg
