### PR TITLE
fix(zb_io): preprocess resolver before parsing

### DIFF
--- a/zb_io/src/network/tap_formula.rs
+++ b/zb_io/src/network/tap_formula.rs
@@ -58,6 +58,17 @@ static REBUILD_RE: LazyLock<Regex> = LazyLock::new(|| {
 static BOTTLE_SHA_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"([a-z0-9_]+):\s*"([0-9a-f]{64})""#).expect("BOTTLE_SHA_RE must compile")
 });
+static ON_PLATFORM_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"^\s*on_(macos|linux|arm|intel)\s+do\b"#).expect("ON_PLATFORM_RE must compile")
+});
+static HW_CPU_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"^\s*if\s+Hardware::CPU\.(arm|intel)\?"#).expect("HW_CPU_RE must compile")
+});
+static ELSIF_HW_CPU_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"^\s*elsif\s+Hardware::CPU\.(arm|intel)\?"#).expect("ELSIF_HW_CPU_RE must compile")
+});
+static ELSE_LINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^\s*else\s*(?:#.*)?$"#).expect("ELSE_LINE_RE must compile"));
 
 pub fn parse_tap_formula_ref(input: &str) -> Option<TapFormulaRef> {
     let mut parts = input.split('/');
@@ -77,13 +88,263 @@ pub fn parse_tap_formula_ref(input: &str) -> Option<TapFormulaRef> {
     })
 }
 
+/// Pre-processes a tap formula Ruby source to resolve platform-conditional blocks
+/// (`on_macos do`, `on_linux do`, `on_arm do`, `on_intel do`), architecture
+/// conditionals (`if Hardware::CPU.arm?`, `if Hardware::CPU.intel?`), and Ruby
+/// `#{version}` string interpolation so that the downstream regex-based parser
+/// sees the relevant fields at the top level.
+fn preprocess_tap_source(source: &str) -> String {
+    let resolved = resolve_on_platform_blocks(source);
+    let resolved = resolve_arch_conditionals(&resolved);
+    resolve_version_interpolation(&resolved)
+}
+
+/// Returns `Some(true)` when the line opens a platform block that matches the
+/// current compile target, `Some(false)` when it opens one that does not
+/// match, and `None` when the line is not a platform block at all.
+fn platform_block_matches(trimmed: &str) -> Option<bool> {
+    let cap = ON_PLATFORM_RE.captures(trimmed)?;
+    let platform = cap.get(1)?.as_str();
+    Some(match platform {
+        "macos" => cfg!(target_os = "macos"),
+        "linux" => cfg!(target_os = "linux"),
+        "arm" => cfg!(target_arch = "aarch64"),
+        "intel" => cfg!(target_arch = "x86_64"),
+        _ => false,
+    })
+}
+
+/// Returns `Some(true)` when the line is an `if Hardware::CPU.{arm,intel}?`
+/// conditional that matches the current architecture, `Some(false)` when it
+/// does not match, and `None` when the line is not an arch conditional.
+fn arch_conditional_matches(trimmed: &str) -> Option<bool> {
+    let cap = HW_CPU_RE.captures(trimmed)?;
+    let arch = cap.get(1)?.as_str();
+    Some(match arch {
+        "arm" => cfg!(target_arch = "aarch64"),
+        "intel" => cfg!(target_arch = "x86_64"),
+        _ => false,
+    })
+}
+
+/// Returns `Some(true)` when the line is an `elsif Hardware::CPU.{arm,intel}?`
+/// conditional that matches the current architecture, `Some(false)` when it
+/// does not match, and `None` when the line is not an elsif arch conditional.
+fn arch_conditional_matches_elsif(trimmed: &str) -> Option<bool> {
+    let cap = ELSIF_HW_CPU_RE.captures(trimmed)?;
+    let arch = cap.get(1)?.as_str();
+    Some(match arch {
+        "arm" => cfg!(target_arch = "aarch64"),
+        "intel" => cfg!(target_arch = "x86_64"),
+        _ => false,
+    })
+}
+
+/// Counts how many Ruby blocks are opened by a single source line (via `do`
+/// keywords and Ruby control-flow keywords like `if`, `def`, etc.).
+fn count_block_opens(trimmed: &str) -> usize {
+    let mut count = DO_RE.find_iter(trimmed).count();
+    if KEYWORD_START_RE.is_match(trimmed) {
+        count += 1;
+    }
+    count
+}
+
+/// Starting from `start` (the first line inside the block), finds the index
+/// of the `end` line that closes the block opened immediately before `start`.
+/// Returns `lines.len()` if no matching `end` is found.
+fn find_matching_end(lines: &[&str], start: usize) -> usize {
+    let mut depth = 1usize;
+    for (i, line) in lines.iter().enumerate().skip(start) {
+        let trimmed = line.trim();
+        if END_RE.is_match(trimmed) {
+            depth -= 1;
+            if depth == 0 {
+                return i;
+            }
+        } else {
+            depth += count_block_opens(trimmed);
+        }
+    }
+    lines.len()
+}
+
+/// A single branch from an `if … elsif … else` block. `lines` is the branch
+/// body; `matches` is `Some(bool)` for if/elsif (whether the arch conditional
+/// matches) and `None` for else.
+type ArchBranch<'a> = (Vec<&'a str>, Option<bool>);
+
+/// Splits the body of an `if … elsif … else … end` block into branches.
+/// Returns `(branches, end_index)`.
+fn split_if_else_elsif<'a>(
+    lines: &[&'a str],
+    start: usize,
+    if_matches: bool,
+) -> (Vec<ArchBranch<'a>>, usize) {
+    let mut branches: Vec<ArchBranch<'a>> = Vec::new();
+    let mut current_branch = Vec::new();
+    let mut current_matches = Some(if_matches);
+    let mut depth = 0usize;
+    let mut i = start;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        if END_RE.is_match(trimmed) {
+            if depth == 0 {
+                branches.push((current_branch, current_matches));
+                return (branches, i);
+            }
+            depth -= 1;
+        } else if depth == 0 {
+            if let Some(elsif_matches) = arch_conditional_matches_elsif(trimmed) {
+                branches.push((current_branch, current_matches));
+                current_branch = Vec::new();
+                current_matches = Some(elsif_matches);
+                i += 1;
+                continue;
+            } else if ELSE_LINE_RE.is_match(trimmed) {
+                branches.push((current_branch, current_matches));
+                current_branch = Vec::new();
+                current_matches = None;
+                i += 1;
+                continue;
+            }
+            depth += count_block_opens(trimmed);
+        } else {
+            depth += count_block_opens(trimmed);
+        }
+
+        current_branch.push(lines[i]);
+        i += 1;
+    }
+
+    branches.push((current_branch, current_matches));
+    (branches, lines.len().saturating_sub(1))
+}
+
+/// Resolves `on_macos do`/`on_linux do`/`on_arm do`/`on_intel do` blocks.
+/// Matching platform blocks are unwrapped (wrapper lines removed, content
+/// kept). Non-matching platform blocks are removed entirely.
+///
+/// Inside `bottle do` blocks, all platform sub-blocks are unconditionally
+/// unwrapped because the bottle block is a data declaration listing downloads
+/// for every platform, not conditional code.
+fn resolve_on_platform_blocks(source: &str) -> String {
+    resolve_on_platform_blocks_inner(source, false)
+}
+
+fn resolve_on_platform_blocks_inner(source: &str, inside_bottle: bool) -> String {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut result: Vec<String> = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        // Detect entering a `bottle do` block so nested platform blocks are
+        // unwrapped unconditionally.
+        if !inside_bottle && BOTTLE_START_RE.is_match(trimmed) {
+            result.push(lines[i].to_string());
+            let end_idx = find_matching_end(&lines, i + 1);
+            let inner: String = lines[i + 1..end_idx.min(lines.len())].join("\n");
+            let resolved = resolve_on_platform_blocks_inner(&inner, true);
+            for line in resolved.lines() {
+                result.push(line.to_string());
+            }
+            if end_idx < lines.len() {
+                result.push(lines[end_idx].to_string());
+                i = end_idx + 1;
+            } else {
+                i = lines.len();
+            }
+            continue;
+        }
+
+        if let Some(matches) = platform_block_matches(trimmed) {
+            let end_idx = find_matching_end(&lines, i + 1);
+            if inside_bottle || matches {
+                let inner: String = lines[i + 1..end_idx.min(lines.len())].join("\n");
+                let resolved = resolve_on_platform_blocks_inner(&inner, inside_bottle);
+                for line in resolved.lines() {
+                    result.push(line.to_string());
+                }
+            }
+            i = if end_idx < lines.len() {
+                end_idx + 1
+            } else {
+                lines.len()
+            };
+            continue;
+        }
+
+        result.push(lines[i].to_string());
+        i += 1;
+    }
+
+    result.join("\n")
+}
+
+/// Resolves `if Hardware::CPU.arm?` / `if Hardware::CPU.intel?` conditionals,
+/// including `elsif` branches. The first matching branch is kept; all others
+/// are removed.
+fn resolve_arch_conditionals(source: &str) -> String {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut result: Vec<String> = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        if let Some(if_matches) = arch_conditional_matches(trimmed) {
+            let (branches, end_idx) = split_if_else_elsif(&lines, i + 1, if_matches);
+            let branch = branches
+                .into_iter()
+                .find_map(|(lines, matches)| match matches {
+                    Some(true) => Some(lines),
+                    Some(false) => None,
+                    None => Some(lines),
+                })
+                .unwrap_or_default();
+            let branch_source = branch.join("\n");
+            let resolved = resolve_arch_conditionals(&branch_source);
+            for line in resolved.lines() {
+                result.push(line.to_string());
+            }
+            i = if end_idx < lines.len() {
+                end_idx + 1
+            } else {
+                lines.len()
+            };
+            continue;
+        }
+
+        result.push(lines[i].to_string());
+        i += 1;
+    }
+
+    result.join("\n")
+}
+
+/// Replaces `#{version}` in the source with the actual version string extracted
+/// from the `version "..."` directive, enabling correct URL resolution for tap
+/// formulas that use Ruby string interpolation.
+fn resolve_version_interpolation(source: &str) -> String {
+    if let Some(version) = parse_version(source) {
+        source.replace("#{version}", &version)
+    } else {
+        source.to_string()
+    }
+}
+
 pub fn parse_tap_formula_ruby(spec: &TapFormulaRef, source: &str) -> Result<Formula, Error> {
-    let stable = parse_version(source).unwrap_or_else(|| "0".to_string());
-    let revision = parse_revision(source).unwrap_or(0);
-    let dependencies = parse_runtime_dependencies(source);
-    let build_dependencies = parse_build_dependencies(source);
-    let parsed_source_url = parse_source_url(source);
-    let bottle = parse_bottle(spec, source, &stable, revision);
+    let source = preprocess_tap_source(source);
+    let stable = parse_version(&source).unwrap_or_else(|| "0".to_string());
+    let revision = parse_revision(&source).unwrap_or(0);
+    let dependencies = parse_runtime_dependencies(&source);
+    let build_dependencies = parse_build_dependencies(&source);
+    let parsed_source_url = parse_source_url(&source);
+    let bottle = parse_bottle(spec, &source, &stable, revision);
 
     let source_url = match parsed_source_url {
         ParsedSourceUrl::PresentWithChecksum(source_url) => Some(source_url),
@@ -786,5 +1047,336 @@ end
 
         let err = parse_tap_formula_ruby(&spec, source).unwrap_err();
         assert!(matches!(err, Error::UnsupportedFormula { .. }));
+    }
+
+    #[test]
+    fn resolves_on_platform_blocks_in_tap_formula() {
+        let source = r#"
+class Sag < Formula
+  version "0.2.2"
+
+  on_macos do
+    url "https://example.com/sag_darwin.tar.gz"
+    sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  end
+
+  on_linux do
+    url "https://example.com/sag_linux.tar.gz"
+    sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  end
+end
+"#;
+
+        let spec = TapFormulaRef {
+            owner: "steipete".to_string(),
+            repo: "tap".to_string(),
+            formula: "sag".to_string(),
+        };
+
+        let formula = parse_tap_formula_ruby(&spec, source).unwrap();
+        assert_eq!(formula.versions.stable, "0.2.2");
+
+        let stable = formula
+            .urls
+            .as_ref()
+            .and_then(|u| u.stable.as_ref())
+            .expect("stable source url should be parsed");
+
+        #[cfg(target_os = "macos")]
+        {
+            assert_eq!(stable.url, "https://example.com/sag_darwin.tar.gz");
+            assert_eq!(
+                stable.checksum.as_deref(),
+                Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            );
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(stable.url, "https://example.com/sag_linux.tar.gz");
+            assert_eq!(
+                stable.checksum.as_deref(),
+                Some("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+            );
+        }
+    }
+
+    #[test]
+    fn resolves_nested_arch_conditional_in_on_platform_block() {
+        #[cfg(target_os = "linux")]
+        {
+            let source = r#"
+class Sag < Formula
+  version "0.2.2"
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://example.com/sag_arm.tar.gz"
+      sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      depends_on "go" => :build
+    else
+      url "https://example.com/sag_x86.tar.gz"
+      sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    end
+  end
+end
+"#;
+
+            let spec = TapFormulaRef {
+                owner: "steipete".to_string(),
+                repo: "tap".to_string(),
+                formula: "sag".to_string(),
+            };
+            let formula = parse_tap_formula_ruby(&spec, source).unwrap();
+            let stable = formula
+                .urls
+                .as_ref()
+                .and_then(|u| u.stable.as_ref())
+                .expect("stable source url should be parsed");
+
+            #[cfg(target_arch = "aarch64")]
+            {
+                assert_eq!(stable.url, "https://example.com/sag_arm.tar.gz");
+                assert_eq!(formula.build_dependencies, vec!["go".to_string()]);
+            }
+
+            #[cfg(target_arch = "x86_64")]
+            {
+                assert_eq!(stable.url, "https://example.com/sag_x86.tar.gz");
+                assert!(formula.build_dependencies.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn resolves_version_interpolation_in_urls() {
+        let source = r#"
+class Sag < Formula
+  version "0.2.2"
+  url "https://example.com/sag/v#{version}/sag_#{version}_linux.tar.gz"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+end
+"#;
+
+        let spec = TapFormulaRef {
+            owner: "steipete".to_string(),
+            repo: "tap".to_string(),
+            formula: "sag".to_string(),
+        };
+
+        let formula = parse_tap_formula_ruby(&spec, source).unwrap();
+        let stable = formula
+            .urls
+            .as_ref()
+            .and_then(|u| u.stable.as_ref())
+            .expect("stable source url should be parsed");
+        assert_eq!(
+            stable.url,
+            "https://example.com/sag/v0.2.2/sag_0.2.2_linux.tar.gz"
+        );
+    }
+
+    #[test]
+    fn resolves_real_world_sag_formula_with_platform_and_arch_conditionals() {
+        // Closely mirrors the actual steipete/tap/sag formula structure
+        let source = r#"
+class Sag < Formula
+  desc "Command-line ElevenLabs TTS with mac-style flags"
+  homepage "https://github.com/steipete/sag"
+  version "0.2.2"
+  license "MIT"
+
+  on_macos do
+    url "https://github.com/steipete/sag/releases/download/v#{version}/sag_#{version}_darwin_universal.tar.gz"
+    sha256 "0554baef912217d9e1f3988fb6d7492d46d2f49105a5eb9175e3f861f39cd289"
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/steipete/sag/archive/refs/tags/v#{version}.tar.gz"
+      sha256 "82a09382d6803396e29a3fdc1d1d4982ffd97d69b5c6f9b6e31d0fb3818450db"
+      depends_on "go" => :build
+    else
+      url "https://github.com/steipete/sag/releases/download/v#{version}/sag_#{version}_linux_amd64.tar.gz"
+      sha256 "fddfe2553648fd9cd3446610c55176d897850d79f4aa95d60b605d387ffabdc8"
+    end
+  end
+
+  def install
+    if File.exist?("sag")
+      bin.install "sag"
+    else
+      system "go", "build", "./cmd/sag"
+    end
+  end
+
+  test do
+    assert_match version.to_s, shell_output("sag --version")
+  end
+end
+"#;
+
+        let spec = TapFormulaRef {
+            owner: "steipete".to_string(),
+            repo: "tap".to_string(),
+            formula: "sag".to_string(),
+        };
+
+        let formula = parse_tap_formula_ruby(&spec, source).unwrap();
+        assert_eq!(formula.name, "sag");
+        assert_eq!(formula.versions.stable, "0.2.2");
+
+        let stable = formula
+            .urls
+            .as_ref()
+            .and_then(|u| u.stable.as_ref())
+            .expect("stable source url should be parsed");
+
+        // Version interpolation should be resolved
+        assert!(
+            !stable.url.contains("#{version}"),
+            "url should not contain unresolved interpolation: {}",
+            stable.url
+        );
+        assert!(
+            stable.url.contains("0.2.2"),
+            "url should contain resolved version: {}",
+            stable.url
+        );
+
+        #[cfg(target_os = "macos")]
+        {
+            assert_eq!(
+                stable.url,
+                "https://github.com/steipete/sag/releases/download/v0.2.2/sag_0.2.2_darwin_universal.tar.gz"
+            );
+        }
+
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        {
+            assert_eq!(
+                stable.url,
+                "https://github.com/steipete/sag/releases/download/v0.2.2/sag_0.2.2_linux_amd64.tar.gz"
+            );
+            assert!(formula.build_dependencies.is_empty());
+        }
+
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        {
+            assert_eq!(
+                stable.url,
+                "https://github.com/steipete/sag/archive/refs/tags/v0.2.2.tar.gz"
+            );
+            assert_eq!(formula.build_dependencies, vec!["go".to_string()]);
+        }
+    }
+
+    #[test]
+    fn preprocessing_preserves_formulas_without_platform_blocks() {
+        // Ensure formulas without any platform blocks are not affected
+        let source = r#"
+class OhMyPosh < Formula
+  version "29.3.0"
+  url "https://github.com/JanDeDobbeleer/oh-my-posh/archive/v29.3.0.tar.gz"
+  sha256 "ff39f6ef2b4ca2d7d766f2802520b023986a5d6dbcd59fba685a9e5bacf41993"
+  depends_on "go@1.26" => :build
+end
+"#;
+
+        let spec = TapFormulaRef {
+            owner: "jandedobbeleer".to_string(),
+            repo: "oh-my-posh".to_string(),
+            formula: "oh-my-posh".to_string(),
+        };
+
+        let formula = parse_tap_formula_ruby(&spec, source).unwrap();
+        assert_eq!(formula.versions.stable, "29.3.0");
+        let stable = formula
+            .urls
+            .as_ref()
+            .and_then(|u| u.stable.as_ref())
+            .expect("stable source url should be parsed");
+        assert_eq!(
+            stable.url,
+            "https://github.com/JanDeDobbeleer/oh-my-posh/archive/v29.3.0.tar.gz"
+        );
+        assert_eq!(formula.build_dependencies, vec!["go@1.26".to_string()]);
+    }
+
+    #[test]
+    fn resolves_on_arm_and_on_intel_blocks() {
+        let source = r#"
+class Example < Formula
+  version "1.0.0"
+  on_arm do
+    url "https://example.com/example_arm.tar.gz"
+    sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  end
+  on_intel do
+    url "https://example.com/example_x86.tar.gz"
+    sha256 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  end
+end
+"#;
+
+        let spec = TapFormulaRef {
+            owner: "someone".to_string(),
+            repo: "tap".to_string(),
+            formula: "example".to_string(),
+        };
+
+        let formula = parse_tap_formula_ruby(&spec, source).unwrap();
+        let stable = formula
+            .urls
+            .as_ref()
+            .and_then(|u| u.stable.as_ref())
+            .expect("stable source url should be parsed");
+
+        #[cfg(target_arch = "aarch64")]
+        assert_eq!(stable.url, "https://example.com/example_arm.tar.gz");
+
+        #[cfg(target_arch = "x86_64")]
+        assert_eq!(stable.url, "https://example.com/example_x86.tar.gz");
+    }
+
+    #[test]
+    fn platform_deps_are_resolved_from_matching_block() {
+        let source = r#"
+class Example < Formula
+  version "1.0.0"
+  url "https://example.com/example.tar.gz"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  depends_on "common-dep"
+
+  on_macos do
+    depends_on "macos-only-dep"
+  end
+
+  on_linux do
+    depends_on "linux-only-dep"
+  end
+end
+"#;
+
+        let spec = TapFormulaRef {
+            owner: "someone".to_string(),
+            repo: "tap".to_string(),
+            formula: "example".to_string(),
+        };
+
+        let formula = parse_tap_formula_ruby(&spec, source).unwrap();
+        assert!(formula.dependencies.contains(&"common-dep".to_string()));
+
+        #[cfg(target_os = "macos")]
+        {
+            assert!(formula.dependencies.contains(&"macos-only-dep".to_string()));
+            assert!(!formula.dependencies.contains(&"linux-only-dep".to_string()));
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            assert!(formula.dependencies.contains(&"linux-only-dep".to_string()));
+            assert!(!formula.dependencies.contains(&"macos-only-dep".to_string()));
+        }
     }
 }


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [X] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

Regression from #203 

Our parser wasn't taking into consideration taps that use Ruby platform blocks (i.e. `on_macos do`, `on_linux do`, etc.) They weren't parseable by the regex-based parser since it couldn't see through nested `do...end` structure. I added a preprocessing pass that unwraps matching platform/arch conditionals and resolves `#{version}` interpolation before parsing. Inside bottle do blocks, all platform sub-blocks are kept unconditionally since bottles are data declarations, not conditional code.

Fixes #240.


