### PR TITLE
ci: add SHA256 checksums and SLSA build provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ on:
 
 permissions:
   contents: write
+  attestations: write
+  id-token: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -109,6 +111,17 @@ jobs:
           path: assets
           pattern: "zb*-*"
           merge-multiple: true
+
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          cd assets
+          sha256sum -- * > SHA256SUMS
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@v3.2.0
+        with:
+          subject-checksums: assets/SHA256SUMS
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
- [x] I have run all relevant linters for this PR.
- [x] I have read and will follow the contributing guidelines.

#

- [x] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [ ] I have not used AI for _any_ portion of this PR.

AI was used to review the workflow changes.

---

Adds SHA256 checksums and [SLSA](https://slsa.dev/) build provenance attestation to the release workflow, so users can verify the integrity and origin of release artifacts.

- Generate and publish a `SHA256SUMS` file alongside release binaries
- Attest artifacts via [`actions/attest-build-provenance@v3.2.0`](https://github.com/actions/attest-build-provenance) using `subject-checksums`, making the checksums file the single source of truth for both the published checksums and the attestation subjects
- Add required `attestations: write` and `id-token: write` permissions

Linting: `cargo fmt`, `cargo clippy`, and [`actionlint`](https://github.com/rhysd/actionlint) all pass. The two failing tests (`build::executor::tests::run_build_*`) are preexisting and unrelated (Ruby shim version incompatibility).

**Follow-up:** If accepted, I'm willing to add checksum verification to the installer script so users get end-to-end integrity validation from build to install.