### PR TITLE
refactor(zb_cli): remove yes alias from auto-init

### DIFF
--- a/zb_cli/src/cli.rs
+++ b/zb_cli/src/cli.rs
@@ -19,12 +19,7 @@ pub struct Cli {
     )]
     pub concurrency: usize,
 
-    #[arg(
-        long = "auto-init",
-        alias = "yes",
-        global = true,
-        env = "ZEROBREW_AUTO_INIT"
-    )]
+    #[arg(long = "auto-init", global = true, env = "ZEROBREW_AUTO_INIT")]
     pub auto_init: bool,
 
     #[arg(long, short = 'v', global = true, action = clap::ArgAction::Count)]


### PR DESCRIPTION
- [x] I have run all relevant linters for this PR.
- [x] I have read and will follow the contributing guidelines.
- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [x] I have not used AI for _any_ portion of this PR.

## Description

As discussed [here](https://github.com/lucasgelfond/zerobrew/pull/285#discussion_r2902907919), the global `--auto-init` has a `--yes` alias which appears to conflict with other `--yes` / `-y` flags. To address this, the `--yes` alias has been removed.

