### PR TITLE
fix(install): strip zerobrews bin paths from `PATH` before running installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,6 +77,22 @@ fi
 export ZEROBREW_ROOT
 export ZEROBREW_PREFIX
 
+# Ensure system tools are used instead of zerobrew-installed ones.
+# A prior `zb init` adds $ZEROBREW_PREFIX/bin to PATH, which can cause
+# zerobrew's curl/git (linked against zerobrew's OpenSSL) to be used by
+# this script. On some macOS versions that leads to dyld symbol errors.
+# see https://github.com/lucasgelfond/zerobrew/issues/288
+sanitized_path=""
+IFS=':' read -ra _path_parts <<< "$PATH"
+for _p in "${_path_parts[@]}"; do
+    case "$_p" in
+        "$ZEROBREW_PREFIX"/bin|"$ZEROBREW_ROOT"/bin) ;;
+        *) sanitized_path="${sanitized_path:+$sanitized_path:}$_p" ;;
+    esac
+done
+export PATH="$sanitized_path"
+unset sanitized_path _path_parts _p
+
 # Prevent running with sudo - the script handles its own privilege escalation
 if [[ $EUID -eq 0 ]]; then
     error_exit "Do not run this script with sudo or as root. The installer will automatically request privileges when needed."


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [X] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

Closes #288 

After a prior `zb init`, the user's shell has `$ZEROBREW_PREFIX/bin` in `PATH`. When they re-run the install script, curl resolves to zerobrew's curl (which is linked against zerobrew's `openssl@3/3.6.1`). On macOS Tahoe 26.2, that OpenSSL has an ABI mismatch (`_ASN1_INTEGER_cmp` missing), causing the `dyld` crash. The zb binary itself is fine.