### PR TITLE
fix(zb_io): added SQLite schema versioning with sequential migrations and downgrade protection

### DIFF
--- a/zb_io/src/network/cache.rs
+++ b/zb_io/src/network/cache.rs
@@ -19,19 +19,58 @@ pub struct CacheEntry {
 }
 
 impl ApiCache {
+    const SCHEMA_VERSION: u32 = 1;
+
     pub fn open(path: &Path) -> Result<Self, rusqlite::Error> {
         let conn = Connection::open(path)?;
-        Self::init_schema(&conn)?;
+        Self::migrate(&conn)?;
         Ok(Self { conn })
     }
 
     pub fn in_memory() -> Result<Self, rusqlite::Error> {
         let conn = Connection::open_in_memory()?;
-        Self::init_schema(&conn)?;
+        Self::migrate(&conn)?;
         Ok(Self { conn })
     }
 
-    fn init_schema(conn: &Connection) -> Result<(), rusqlite::Error> {
+    fn get_schema_version(conn: &Connection) -> Result<u32, rusqlite::Error> {
+        let version: u32 = conn.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+        Ok(version)
+    }
+
+    fn set_schema_version(conn: &Connection, version: u32) -> Result<(), rusqlite::Error> {
+        conn.execute(&format!("PRAGMA user_version = {}", version), [])?;
+        Ok(())
+    }
+
+    fn migrate(conn: &Connection) -> Result<(), rusqlite::Error> {
+        let current_version = Self::get_schema_version(conn)?;
+
+        if current_version > Self::SCHEMA_VERSION {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+
+        if current_version == Self::SCHEMA_VERSION {
+            return Ok(());
+        }
+
+        for version in current_version..Self::SCHEMA_VERSION {
+            let next_version = version + 1;
+            Self::migrate_to_version(conn, next_version)?;
+            Self::set_schema_version(conn, next_version)?;
+        }
+
+        Ok(())
+    }
+
+    fn migrate_to_version(conn: &Connection, version: u32) -> Result<(), rusqlite::Error> {
+        match version {
+            1 => Self::migrate_to_v1(conn),
+            _ => Err(rusqlite::Error::InvalidQuery),
+        }
+    }
+
+    fn migrate_to_v1(conn: &Connection) -> Result<(), rusqlite::Error> {
         conn.execute(
             "CREATE TABLE IF NOT EXISTS api_cache (
                 url TEXT PRIMARY KEY,
@@ -130,5 +169,64 @@ mod tests {
     fn clear_on_empty_cache_returns_zero() {
         let cache = ApiCache::in_memory().unwrap();
         assert_eq!(cache.clear().unwrap(), 0);
+    }
+
+    #[test]
+    fn new_database_starts_at_version_1() {
+        let cache = ApiCache::in_memory().expect("failed to create cache");
+        let version = ApiCache::get_schema_version(&cache.conn).expect("failed to get version");
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn migration_is_idempotent() {
+        let cache = ApiCache::in_memory().expect("failed to create cache");
+        ApiCache::migrate(&cache.conn).expect("first migration failed");
+        ApiCache::migrate(&cache.conn).expect("second migration failed");
+        let version = ApiCache::get_schema_version(&cache.conn).expect("failed to get version");
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn rejects_future_schema_version() {
+        let conn = Connection::open_in_memory().expect("failed to open connection");
+        ApiCache::set_schema_version(&conn, 999).expect("failed to set version");
+        let err = ApiCache::migrate(&conn).unwrap_err();
+        assert!(matches!(err, rusqlite::Error::InvalidQuery));
+    }
+
+    #[test]
+    fn migration_preserves_existing_data() {
+        let conn = Connection::open_in_memory().expect("failed to open connection");
+
+        conn.execute(
+            "CREATE TABLE api_cache (
+                url TEXT PRIMARY KEY,
+                etag TEXT,
+                last_modified TEXT,
+                body TEXT NOT NULL,
+                cached_at INTEGER NOT NULL
+            )",
+            [],
+        )
+        .expect("failed to create old schema");
+
+        conn.execute(
+            "INSERT INTO api_cache VALUES ('https://example.com', 'abc', NULL, 'data', 123)",
+            [],
+        )
+        .expect("failed to insert test data");
+
+        ApiCache::migrate(&conn).expect("migration failed");
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM api_cache", [], |row| row.get(0))
+            .expect("failed to count rows");
+        assert_eq!(count, 1);
+
+        let url: String = conn
+            .query_row("SELECT url FROM api_cache", [], |row| row.get(0))
+            .expect("failed to query data");
+        assert_eq!(url, "https://example.com");
     }
 }

--- a/zb_io/src/storage/db.rs
+++ b/zb_io/src/storage/db.rs
@@ -17,24 +17,71 @@ pub struct InstalledKeg {
 }
 
 impl Database {
+    const SCHEMA_VERSION: u32 = 1;
+
     pub fn open(path: &Path) -> Result<Self, Error> {
         let conn = Connection::open(path).map_err(Error::store("failed to open database"))?;
-
-        Self::init_schema(&conn)?;
-
+        Self::migrate(&conn)?;
         Ok(Self { conn })
     }
 
     pub fn in_memory() -> Result<Self, Error> {
         let conn =
             Connection::open_in_memory().map_err(Error::store("failed to open in-memory db"))?;
-
-        Self::init_schema(&conn)?;
-
+        Self::migrate(&conn)?;
         Ok(Self { conn })
     }
 
-    fn init_schema(conn: &Connection) -> Result<(), Error> {
+    fn get_schema_version(conn: &Connection) -> Result<u32, Error> {
+        let version: u32 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .map_err(Error::store("failed to query schema version"))?;
+        Ok(version)
+    }
+
+    fn set_schema_version(conn: &Connection, version: u32) -> Result<(), Error> {
+        conn.execute(&format!("PRAGMA user_version = {}", version), [])
+            .map_err(Error::store("failed to set schema version"))?;
+        Ok(())
+    }
+
+    fn migrate(conn: &Connection) -> Result<(), Error> {
+        let current_version = Self::get_schema_version(conn)?;
+
+        if current_version > Self::SCHEMA_VERSION {
+            return Err(Error::StoreCorruption {
+                message: format!(
+                    "database schema version {} is newer than supported version {}. \
+                     Please upgrade zerobrew",
+                    current_version,
+                    Self::SCHEMA_VERSION
+                ),
+            });
+        }
+
+        if current_version == Self::SCHEMA_VERSION {
+            return Ok(());
+        }
+
+        for version in current_version..Self::SCHEMA_VERSION {
+            let next_version = version + 1;
+            Self::migrate_to_version(conn, next_version)?;
+            Self::set_schema_version(conn, next_version)?;
+        }
+
+        Ok(())
+    }
+
+    fn migrate_to_version(conn: &Connection, version: u32) -> Result<(), Error> {
+        match version {
+            1 => Self::migrate_to_v1(conn),
+            _ => Err(Error::StoreCorruption {
+                message: format!("unknown migration version {}", version),
+            }),
+        }
+    }
+
+    fn migrate_to_v1(conn: &Connection) -> Result<(), Error> {
         conn.execute_batch(
             "
             CREATE TABLE IF NOT EXISTS installed_kegs (
@@ -58,7 +105,7 @@ impl Database {
             );
             ",
         )
-        .map_err(Error::store("failed to initialize schema"))?;
+        .map_err(Error::store("failed to create initial schema"))?;
 
         Ok(())
     }
@@ -470,5 +517,58 @@ mod tests {
             err.to_string()
                 .contains("failed to query previous store key")
         );
+    }
+
+    #[test]
+    fn new_database_starts_at_version_1() {
+        let db = Database::in_memory().expect("failed to create database");
+        let version = Database::get_schema_version(&db.conn).expect("failed to get version");
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn migration_is_idempotent() {
+        let db = Database::in_memory().expect("failed to create database");
+        Database::migrate(&db.conn).expect("first migration failed");
+        Database::migrate(&db.conn).expect("second migration failed");
+        let version = Database::get_schema_version(&db.conn).expect("failed to get version");
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn rejects_future_schema_version() {
+        let conn = Connection::open_in_memory().expect("failed to open connection");
+        Database::set_schema_version(&conn, 999).expect("failed to set version");
+        let err = Database::migrate(&conn).unwrap_err();
+        assert!(matches!(err, Error::StoreCorruption { .. }));
+        assert!(err.to_string().contains("newer than supported version"));
+    }
+
+    #[test]
+    fn migration_preserves_existing_data() {
+        let conn = Connection::open_in_memory().expect("failed to open connection");
+
+        conn.execute_batch(
+            "CREATE TABLE installed_kegs (
+                name TEXT PRIMARY KEY,
+                version TEXT NOT NULL,
+                store_key TEXT NOT NULL,
+                installed_at INTEGER NOT NULL
+            );
+            INSERT INTO installed_kegs VALUES ('test', '1.0.0', 'key123', 1234567890);",
+        )
+        .expect("failed to create old schema");
+
+        Database::migrate(&conn).expect("migration failed");
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM installed_kegs", [], |row| row.get(0))
+            .expect("failed to count rows");
+        assert_eq!(count, 1);
+
+        let name: String = conn
+            .query_row("SELECT name FROM installed_kegs", [], |row| row.get(0))
+            .expect("failed to query data");
+        assert_eq!(name, "test");
     }
 }


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [X] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

Closes #295 

Adds SQLite schema versioning for both the main database and API cache database using `PRAGMA user_version` to track versions. The migration system runs migrations sequentially from the current version to the target version, rejects downgrades by returning an error when the database version exceeds the code version, and preserves existing data through idempotent migrations. 



