### PR TITLE
fix(zb_cli): removed redundant flags from `Outdated` variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-03-14
+
+### Fixed
+- Fix `zb outdated` panic caused by clap type mismatch between global `verbose` (u8 count) and subcommand `verbose` (bool) flags ([#308](https://github.com/lucasgelfond/zerobrew/pull/308))
+
 ## [0.2.0] - 2026-03-12
 
 ### Added
@@ -71,7 +76,8 @@ To get an idea of the initial features zerobrew supports, take a look at the [RE
 
 See the [full commit history](https://github.com/lucasgelfond/zerobrew/commits/v0.1.1) for more details.
 
-[Unreleased]: https://github.com/lucasgelfond/zerobrew/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/lucasgelfond/zerobrew/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/lucasgelfond/zerobrew/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/lucasgelfond/zerobrew/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/lucasgelfond/zerobrew/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/lucasgelfond/zerobrew/releases/tag/v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "zb_cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2921,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "zb_core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -2929,7 +2929,7 @@ dependencies = [
 
 [[package]]
 name = "zb_io"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "arwen",
  "flate2",

--- a/zb_cli/Cargo.toml
+++ b/zb_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zb_cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version.workspace = true
 

--- a/zb_cli/src/bin/zb.rs
+++ b/zb_cli/src/bin/zb.rs
@@ -80,11 +80,9 @@ async fn run(cli: Cli) -> Result<(), zb_core::Error> {
         Commands::Info { formula } => commands::info::execute(&mut installer, formula),
         Commands::Gc => commands::gc::execute(&mut installer),
         Commands::Update => commands::update::execute(&mut installer),
-        Commands::Outdated {
-            quiet,
-            verbose,
-            json,
-        } => commands::outdated::execute(&mut installer, quiet, verbose, json).await,
+        Commands::Outdated { json } => {
+            commands::outdated::execute(&mut installer, cli.quiet, cli.verbose > 0, json).await
+        }
         Commands::Reset { yes } => commands::reset::execute(&root, &prefix, yes, &mut ui),
         Commands::Run { formula, args } => {
             commands::run::execute(&mut installer, formula, args).await

--- a/zb_cli/src/cli.rs
+++ b/zb_cli/src/cli.rs
@@ -144,14 +144,6 @@ pub enum Commands {
     },
     Update,
     Outdated {
-        /// Show only package names
-        #[arg(short, long, conflicts_with_all = ["verbose", "json"])]
-        quiet: bool,
-
-        /// Show detailed version information
-        #[arg(short, long, conflicts_with_all = ["quiet", "json"])]
-        verbose: bool,
-
         /// Output as JSON
         #[arg(long, conflicts_with_all = ["quiet", "verbose"])]
         json: bool,

--- a/zb_core/Cargo.toml
+++ b/zb_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zb_core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version.workspace = true
 

--- a/zb_io/Cargo.toml
+++ b/zb_io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zb_io"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 rust-version.workspace = true
 


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [X] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

the `Outdated` subcommand defined its own `verbose: bool` and `quiet: bool` flags, but the top-level Cli struct already had global `verbose: u8` (a count flag via `ArgAction::Count`) and `quiet: bool`. Since the global flags propagate into subcommands, clap encountered two verbose arguments with different types (`u8` vs `bool`) and panicked on the type mismatch.

i removed the redundant verbose and quiet fields from the `Outdated` variant and wired the global `cli.verbose` and `cli.quiet` flags through instead.

this is a regression of #275 