### PR TITLE
fix(zb_io): only match version segments withing Cellar-style paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Chinese translation of the README ([#315](https://github.com/lucasgelfond/zerobrew/pull/316))
+- Regex matches on `/Cellar/<pkg>/)([^/]+)(/)`, so it only matches version segments within Cellar-style paths ([#317](https://github.com/lucasgelfond/zerobrew/pull/317))
 
 ### Added
 - `zb doctor` command with `--repair` flag for state diagnosis and recovery ([#314](https://github.com/lucasgelfond/zerobrew/pull/314))

--- a/zb_io/src/extraction/patch/macos.rs
+++ b/zb_io/src/extraction/patch/macos.rs
@@ -238,9 +238,7 @@ pub fn patch_homebrew_placeholders(
     let cellar_str = cellar_dir.to_string_lossy().to_string();
     let prefix_str = prefix.to_string_lossy().to_string();
 
-    // Regex to match version mismatches in paths like /Cellar/ffmpeg/8.0.1_1/
-    // We'll fix references to this package with wrong versions
-    let version_pattern = format!(r"(/{}/)([^/]+)(/)", regex::escape(pkg_name));
+    let version_pattern = format!(r"(/Cellar/{}/)([^/]+)(/)", regex::escape(pkg_name));
     let version_regex = Regex::new(&version_pattern).ok();
 
     // Collect all Mach-O files first (skip symlinks to avoid double-processing)
@@ -318,7 +316,7 @@ pub fn patch_homebrew_placeholders(
         if let Some(re) = &version_regex
             && re.is_match(&new_path)
         {
-            let replacement = format!("/{}/{}/", pkg_name, pkg_version);
+            let replacement = format!("/Cellar/{}/{}/", pkg_name, pkg_version);
             let fixed = re.replace(&new_path, |caps: &regex::Captures| {
                 let matched_version = &caps[2];
                 if matched_version != pkg_version {
@@ -628,6 +626,47 @@ mod tests {
             unchanged, original,
             "binary must be unchanged when prefix cannot be expanded in-place"
         );
+    }
+
+    #[test]
+    fn test_version_regex_only_matches_cellar_paths() {
+        use regex::Regex;
+
+        let pkg_name = "mpdecimal";
+        let pkg_version = "4.0.1";
+        let pattern = format!(r"(/Cellar/{}/)([^/]+)(/)", regex::escape(pkg_name));
+        let re = Regex::new(&pattern).expect("version regex should compile");
+
+        let cellar_path = "/opt/zerobrew/Cellar/mpdecimal/3.9.0/lib/libmpdec.4.dylib";
+        assert!(re.is_match(cellar_path));
+
+        let replacement = format!("/Cellar/{}/{}/", pkg_name, pkg_version);
+        let fixed = re.replace(cellar_path, |caps: &regex::Captures| {
+            let matched_version = &caps[2];
+            if matched_version != pkg_version {
+                replacement.clone()
+            } else {
+                caps[0].to_string()
+            }
+        });
+        assert_eq!(
+            fixed,
+            "/opt/zerobrew/Cellar/mpdecimal/4.0.1/lib/libmpdec.4.dylib"
+        );
+
+        let opt_path = "/opt/zerobrew/opt/mpdecimal/lib/libmpdec.4.dylib";
+        assert!(!re.is_match(opt_path));
+
+        let cellar_same_version = "/opt/zerobrew/Cellar/mpdecimal/4.0.1/lib/libmpdec.4.dylib";
+        let unchanged = re.replace(cellar_same_version, |caps: &regex::Captures| {
+            let matched_version = &caps[2];
+            if matched_version != pkg_version {
+                replacement.clone()
+            } else {
+                caps[0].to_string()
+            }
+        });
+        assert_eq!(unchanged, cellar_same_version);
     }
 
     #[test]


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [X] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

The version-mismatch regex on used the pattern (`/<pkg_name>/)([^/]+)(/)`, which matched `/<pkg_name>/` anywhere in a path. For a package like `mpdecimal`, this matched both Cellar paths (`/Cellar/mpdecimal/3.9.0/`) and opt-style paths (`/opt/mpdecimal/lib/`). 

In the opt case, it captured lib as the "version", decided it didn't match the real version, and replaced i,  dropping the `/lib/` directory component and producing broken paths like `/opt/zerobrew/opt/mpdecimal/4.0.1/libmpdec.4.dylib`.

This PR changes the regex to match on `/Cellar/<pkg>/)([^/]+)(/)`, so it only matches version segments within Cellar-style paths.

Closes #307 


