### PR TITLE
fix: make `just fmt` apply formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,11 @@ out in the Discord to give us a heads up or open an issue first to discuss your 
 
 This project includes a `Justfile`, Install [just](https://github.com/casey/just) and use these commands instead of `cargo` (for ease of development):
 
-- `just build` Format, lint, then build the binary (Builds debug binary)
+- `just build` Check formatting, lint, then build the binary (Builds debug binary)
 - `just install` Build and install zb to $HOME/.local/bin (Customizable with `$ZEROBREW_BIN`)
 - `just uninstall` Remove all zerobrew installations and configurations
-- `just fmt` Check code formatting
+- `just fmt` Format code with rustfmt
+- `just fmt-check` Check code formatting
 - `just lint` Run clippy with strict warnings
 - `just test` Run all workspace tests (unit & integration)
 

--- a/Justfile
+++ b/Justfile
@@ -46,7 +46,7 @@ default:
 
 [doc('Build the zb binary')]
 [group('build')]
-build: fmt lint
+build: fmt-check lint
     cargo build --bin zb --bin zbx
 
 [doc('Install zb to $ZEROBREW_BIN')]
@@ -185,6 +185,17 @@ reset:
 [group('lint')]
 [script]
 fmt:
+    if command -v rustup &>/dev/null && rustup toolchain list | grep -q nightly; then
+        cargo +nightly fmt --all
+    else
+        echo -e '{{BOLD}}{{YELLOW}}Note:{{NORMAL}} Using stable rustfmt (nightly not available)'
+        cargo fmt --all
+    fi
+
+[doc('Check code formatting with rustfmt')]
+[group('lint')]
+[script]
+fmt-check:
     if command -v rustup &>/dev/null && rustup toolchain list | grep -q nightly; then
         cargo +nightly fmt --all -- --check
     else


### PR DESCRIPTION
- [x] I have run all relevant linters for this PR.
- [x] I have read and will follow the contributing guidelines.


<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [x] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->


makes `just fmt` run `cargo fmt`, so it jsut formats the code, now fromat check is moved to `just fmt-check`