### PR TITLE
docs: add Homebrew tap as alternative install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 curl -fsSL https://zerobrew.rs/install | bash
 ```
 
+Or via Homebrew:
+
+```bash
+brew tap lucasgelfond/zerobrew && brew install zerobrew
+```
+
 After install, run the `export` command it prints (or restart your terminal).
 
 ## Quick start

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,6 +26,12 @@
 curl -fsSL https://zerobrew.rs/install | bash
 ```
 
+或通过 Homebrew 安装：
+
+```bash
+brew tap lucasgelfond/zerobrew && brew install zerobrew
+```
+
 安装完成后，运行它打印的 `export` 命令（或重启终端）。
 
 ## 快速开始 (Quick start)


### PR DESCRIPTION
## Summary

Adds `brew tap lucasgelfond/zerobrew && brew install zerobrew` as an alternative install method in both English and Chinese READMEs. The Homebrew tap is now functional (ref #16).

## Changes

- Add Homebrew install option to `README.md` and `README.zh.md`, beneath the existing curl-based install

## Validation

Verified the tap installs successfully via `brew tap lucasgelfond/zerobrew && brew install zerobrew`.