### PR TITLE
feat(zb_io): support app artifacts for casks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ After install, run the `export` command it prints (or restart your terminal).
 ```bash
 zb install jq                   # install one package
 zb install wget git             # install multiple
+zb install --cask docker        # install a cask
 zb bundle                       # install from Brewfile
 zb bundle install -f myfile     # install from custom file
 zb bundle dump                  # export installed packages to Brewfile

--- a/zb_cli/src/bin/zb.rs
+++ b/zb_cli/src/bin/zb.rs
@@ -55,12 +55,14 @@ async fn run(cli: Cli) -> Result<(), zb_core::Error> {
         Commands::Completion { .. } => unreachable!(),
         Commands::Install {
             formulas,
+            cask,
             no_link,
             build_from_source,
         } => {
             commands::install::execute(
                 &mut installer,
                 formulas,
+                cask,
                 no_link,
                 build_from_source,
                 &mut ui,

--- a/zb_cli/src/cli.rs
+++ b/zb_cli/src/cli.rs
@@ -91,6 +91,18 @@ mod tests {
         let result = Cli::try_parse_from(["zb", "outdated", "--verbose", "--json"]);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn install_accepts_cask_flag() {
+        let cli = Cli::try_parse_from(["zb", "install", "--cask", "docker-desktop"]).unwrap();
+        match cli.command {
+            super::Commands::Install { cask, formulas, .. } => {
+                assert!(cask);
+                assert_eq!(formulas, vec!["docker-desktop"]);
+            }
+            _ => panic!("expected install command"),
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -98,6 +110,8 @@ pub enum Commands {
     Install {
         #[arg(required = true, num_args = 1..)]
         formulas: Vec<String>,
+        #[arg(long)]
+        cask: bool,
         #[arg(long)]
         no_link: bool,
         #[arg(long, short = 's')]

--- a/zb_cli/src/cli.rs
+++ b/zb_cli/src/cli.rs
@@ -110,7 +110,7 @@ pub enum Commands {
     Install {
         #[arg(required = true, num_args = 1..)]
         formulas: Vec<String>,
-        #[arg(long)]
+        #[arg(long, help = "Treat all arguments as casks")]
         cask: bool,
         #[arg(long)]
         no_link: bool,

--- a/zb_cli/src/commands/bundle.rs
+++ b/zb_cli/src/commands/bundle.rs
@@ -39,7 +39,7 @@ async fn install_from_file(
 
     let start = Instant::now();
     for formula in formulas {
-        install::execute(installer, vec![formula], no_link, false, ui).await?;
+        install::execute(installer, vec![formula], false, no_link, false, ui).await?;
     }
 
     println!(

--- a/zb_cli/src/commands/install.rs
+++ b/zb_cli/src/commands/install.rs
@@ -6,11 +6,12 @@ use std::time::Instant;
 use zb_io::{InstallProgress, ProgressCallback};
 
 use crate::ui::StdUi;
-use crate::utils::{normalize_formula_name, suggest_homebrew, suggest_missing_formula_matches};
+use crate::utils::{normalize_install_target, suggest_homebrew, suggest_missing_formula_matches};
 
 pub async fn execute(
     installer: &mut zb_io::Installer,
     formulas: Vec<String>,
+    cask: bool,
     no_link: bool,
     build_from_source: bool,
     ui: &mut StdUi,
@@ -25,7 +26,7 @@ pub async fn execute(
     let mut normalized_names = Vec::new();
     let mut cask_names = Vec::new();
     for formula in &formulas {
-        match normalize_formula_name(formula) {
+        match normalize_install_target(formula, cask) {
             Ok(name) => {
                 if name.starts_with("cask:") {
                     cask_names.push(name);
@@ -34,7 +35,7 @@ pub async fn execute(
                 }
             }
             Err(e) => {
-                suggest_homebrew(formula, &e);
+                suggest_homebrew(formula, cask, &e);
                 return Err(e);
             }
         }
@@ -53,7 +54,7 @@ pub async fn execute(
 
                 if !handled_missing {
                     for formula in &formulas {
-                        suggest_homebrew(formula, &e);
+                        suggest_homebrew(formula, cask, &e);
                     }
                 }
                 return Err(e);
@@ -219,7 +220,7 @@ pub async fn execute(
 
                 if !handled_missing {
                     for formula in &formulas {
-                        suggest_homebrew(formula, &e);
+                        suggest_homebrew(formula, cask, &e);
                     }
                 }
                 return Err(e);

--- a/zb_cli/src/commands/migrate.rs
+++ b/zb_cli/src/commands/migrate.rs
@@ -87,6 +87,7 @@ pub async fn execute(
     crate::commands::install::execute(
         installer,
         formula_names.clone(),
+        false, // cask
         false, // no_link
         false, // build_from_source
         ui,

--- a/zb_cli/src/utils.rs
+++ b/zb_cli/src/utils.rs
@@ -34,6 +34,14 @@ pub fn normalize_formula_name(name: &str) -> Result<String, zb_core::Error> {
     Ok(trimmed.to_string())
 }
 
+pub fn normalize_install_target(name: &str, cask: bool) -> Result<String, zb_core::Error> {
+    let normalized = normalize_formula_name(name)?;
+    if cask && !normalized.starts_with("cask:") {
+        return Ok(format!("cask:{normalized}"));
+    }
+    Ok(normalized)
+}
+
 pub fn format_formula_suggestions(requested: &str, suggestions: &[String]) -> Option<String> {
     if suggestions.is_empty() {
         return None;
@@ -82,7 +90,15 @@ pub async fn suggest_missing_formula_matches(
     false
 }
 
-pub fn suggest_homebrew(formula: &str, error: &zb_core::Error) {
+pub fn suggest_homebrew(formula: &str, cask: bool, error: &zb_core::Error) {
+    let brew_target =
+        normalize_install_target(formula, cask).unwrap_or_else(|_| formula.to_string());
+    let brew_command = if let Some(cask_name) = brew_target.strip_prefix("cask:") {
+        format!("brew install --cask {}", cask_name)
+    } else {
+        format!("brew install {}", formula)
+    };
+
     eprintln!();
     eprintln!(
         "{} This package can't be installed with zerobrew.",
@@ -110,10 +126,7 @@ pub fn suggest_homebrew(formula: &str, error: &zb_core::Error) {
         );
     } else {
         eprintln!("      Try installing with Homebrew instead:");
-        eprintln!(
-            "      {}",
-            style(format!("brew install {}", formula)).cyan()
-        );
+        eprintln!("      {}", style(brew_command).cyan());
     }
 
     eprintln!();
@@ -161,7 +174,8 @@ mod tests {
     use zb_io::{Installer, Linker};
 
     use super::{
-        format_formula_suggestions, normalize_formula_name, suggest_missing_formula_matches,
+        format_formula_suggestions, normalize_formula_name, normalize_install_target,
+        suggest_missing_formula_matches,
     };
 
     #[test]
@@ -184,6 +198,22 @@ mod tests {
     fn normalize_homebrew_cask_prefixes_token() {
         assert_eq!(
             normalize_formula_name("homebrew/cask/docker-desktop").unwrap(),
+            "cask:docker-desktop".to_string()
+        );
+    }
+
+    #[test]
+    fn normalize_install_target_prefixes_cask_flag() {
+        assert_eq!(
+            normalize_install_target("docker-desktop", true).unwrap(),
+            "cask:docker-desktop".to_string()
+        );
+    }
+
+    #[test]
+    fn normalize_install_target_keeps_existing_cask_token() {
+        assert_eq!(
+            normalize_install_target("cask:docker-desktop", true).unwrap(),
             "cask:docker-desktop".to_string()
         );
     }

--- a/zb_io/src/installer/cask.rs
+++ b/zb_io/src/installer/cask.rs
@@ -8,6 +8,12 @@ pub struct CaskBinary {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CaskApp {
+    pub source: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedCask {
     pub install_name: String,
     pub token: String,
@@ -15,6 +21,7 @@ pub struct ResolvedCask {
     pub url: String,
     pub sha256: String,
     pub binaries: Vec<CaskBinary>,
+    pub apps: Vec<CaskApp>,
 }
 
 pub fn resolve_cask(token: &str, cask: &Value) -> Result<ResolvedCask, Error> {
@@ -38,12 +45,13 @@ pub fn resolve_cask(token: &str, cask: &Value) -> Result<ResolvedCask, Error> {
     }
 
     let binaries = parse_binary_artifacts(cask)?;
-    if binaries.is_empty() {
+    let apps = parse_app_artifacts(cask)?;
+    if binaries.is_empty() && apps.is_empty() {
         let found = artifact_types(cask);
         return Err(Error::InvalidArgument {
             message: format!(
-                "cask '{token}' has no binary artifacts (found: {found}); \
-                 only casks with 'binary' artifacts are currently supported"
+                "cask '{token}' has no supported artifacts (found: {found}); \
+                 only casks with 'binary' and 'app' artifacts are currently supported"
             ),
         });
     }
@@ -55,6 +63,7 @@ pub fn resolve_cask(token: &str, cask: &Value) -> Result<ResolvedCask, Error> {
         url,
         sha256,
         binaries,
+        apps,
     })
 }
 
@@ -148,6 +157,29 @@ fn parse_binary_artifacts(cask: &Value) -> Result<Vec<CaskBinary>, Error> {
     Ok(binaries)
 }
 
+fn parse_app_artifacts(cask: &Value) -> Result<Vec<CaskApp>, Error> {
+    let mut apps = Vec::new();
+    let artifacts = cask
+        .get("artifacts")
+        .and_then(Value::as_array)
+        .ok_or_else(|| Error::InvalidArgument {
+            message: "failed to parse cask JSON: missing artifacts array".to_string(),
+        })?;
+
+    for artifact in artifacts {
+        let Some(entries) = artifact.get("app").and_then(Value::as_array) else {
+            continue;
+        };
+
+        for entry in entries {
+            let (source, target) = parse_app_entry(entry)?;
+            apps.push(CaskApp { source, target });
+        }
+    }
+
+    Ok(apps)
+}
+
 fn parse_binary_entry(entry: &Value) -> Result<(String, String), Error> {
     if let Some(path) = entry.as_str() {
         return Ok((path.to_string(), basename(path)?));
@@ -171,13 +203,45 @@ fn parse_binary_entry(entry: &Value) -> Result<(String, String), Error> {
         .map(ToString::to_string)
         .unwrap_or_else(|| basename(source).unwrap_or_else(|_| source.to_string()));
 
-    if target.contains('/') || target.contains('$') || target.contains('~') {
-        return Err(Error::InvalidArgument {
-            message: format!("unsupported cask binary target path '{target}'"),
-        });
-    }
+    validate_relative_target(&target, "binary")?;
 
     Ok((source.to_string(), target))
+}
+
+fn parse_app_entry(entry: &Value) -> Result<(String, String), Error> {
+    if let Some(path) = entry.as_str() {
+        return Ok((path.to_string(), basename(path)?));
+    }
+
+    let array = entry.as_array().ok_or_else(|| Error::InvalidArgument {
+        message: "unsupported cask app artifact shape".to_string(),
+    })?;
+    let source = array
+        .first()
+        .and_then(Value::as_str)
+        .ok_or_else(|| Error::InvalidArgument {
+            message: "unsupported cask app source".to_string(),
+        })?;
+
+    let target = array
+        .get(1)
+        .and_then(Value::as_object)
+        .and_then(|obj| obj.get("target"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| basename(source).unwrap_or_else(|_| source.to_string()));
+
+    validate_relative_target(&target, "app")?;
+    Ok((source.to_string(), target))
+}
+
+fn validate_relative_target(target: &str, artifact_kind: &str) -> Result<(), Error> {
+    if target.contains('/') || target.contains('$') || target.contains('~') {
+        return Err(Error::InvalidArgument {
+            message: format!("unsupported cask {artifact_kind} target path '{target}'"),
+        });
+    }
+    Ok(())
 }
 
 fn basename(path: &str) -> Result<String, Error> {
@@ -240,6 +304,29 @@ mod tests {
         assert_eq!(resolved.binaries.len(), 2);
         assert_eq!(resolved.binaries[0].target, "tool");
         assert_eq!(resolved.binaries[1].target, "tool-two");
+        assert!(resolved.apps.is_empty());
+    }
+
+    #[test]
+    fn resolve_cask_parses_app_targets() {
+        let cask = serde_json::json!({
+            "token": "test",
+            "version": "1.0.0",
+            "url": "https://example.com/test.zip",
+            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "artifacts": [{
+                "app": [
+                    ["Test.app"],
+                    ["Subdir/Other.app", {"target": "Renamed.app"}]
+                ]
+            }]
+        });
+
+        let resolved = resolve_cask("test", &cask).unwrap();
+        assert_eq!(resolved.apps.len(), 2);
+        assert_eq!(resolved.apps[0].target, "Test.app");
+        assert_eq!(resolved.apps[1].source, "Subdir/Other.app");
+        assert_eq!(resolved.apps[1].target, "Renamed.app");
     }
 
     #[test]
@@ -269,7 +356,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_cask_no_binary_artifacts_lists_found_types() {
+    fn resolve_cask_accepts_app_only_casks() {
         let cask = serde_json::json!({
             "token": "ghostty",
             "version": "1.0.0",
@@ -281,10 +368,28 @@ mod tests {
             ]
         });
 
-        let err = resolve_cask("ghostty", &cask).unwrap_err();
+        let resolved = resolve_cask("ghostty", &cask).unwrap();
+        assert_eq!(resolved.apps.len(), 1);
+        assert!(resolved.binaries.is_empty());
+    }
+
+    #[test]
+    fn resolve_cask_no_supported_artifacts_lists_found_types() {
+        let cask = serde_json::json!({
+            "token": "pkg-only",
+            "version": "1.0.0",
+            "url": "https://example.com/pkg-only.pkg",
+            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "artifacts": [
+                { "pkg": ["Pkg.pkg"] },
+                { "zap": [{ "trash": ["~/Library/Application Support/Pkg"] }] }
+            ]
+        });
+
+        let err = resolve_cask("pkg-only", &cask).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("no binary artifacts"), "got: {msg}");
-        assert!(msg.contains("app"), "got: {msg}");
+        assert!(msg.contains("no supported artifacts"), "got: {msg}");
+        assert!(msg.contains("pkg"), "got: {msg}");
         assert!(msg.contains("zap"), "got: {msg}");
     }
 }

--- a/zb_io/src/installer/install/bottle.rs
+++ b/zb_io/src/installer/install/bottle.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use tracing::warn;
 use zb_core::{Error, InstallMethod, formula_token};
@@ -11,6 +11,8 @@ use crate::network::download::{DownloadProgressCallback, DownloadRequest, Downlo
 use crate::progress::InstallProgress;
 
 use super::{Installer, MAX_CORRUPTION_RETRIES, PlannedInstall};
+
+const CASK_APPS_DIR: &str = "Applications";
 
 impl Installer {
     pub(super) async fn process_bottle_item(
@@ -208,6 +210,15 @@ impl Installer {
             );
         }
 
+        if unlink && let Err(e) = uninstall_cask_apps(keg_path) {
+            warn!(
+                formula = %name,
+                version = %version,
+                error = %e,
+                "failed to remove installed apps after install error"
+            );
+        }
+
         if let Err(e) = cellar.remove_keg(name, version) {
             warn!(
                 formula = %name,
@@ -250,13 +261,15 @@ impl Installer {
 
         if crate::extraction::is_archive(&blob_path)? {
             let extracted = self.store.ensure_entry(&cask.sha256, &blob_path)?;
-            stage_cask_binaries(&extracted, &keg_path, &cask)?;
+            stage_cask_artifacts(&extracted, &keg_path, &cask)?;
         } else {
             stage_raw_cask_binary(&blob_path, &keg_path, &cask)?;
         }
 
         let linked_files = if link {
-            self.linker.link_keg(&keg_path)?
+            let mut linked_files = self.linker.link_keg(&keg_path)?;
+            linked_files.extend(link_cask_apps(&keg_path, self.app_dir(), &cask)?);
+            linked_files
         } else {
             Vec::new()
         };
@@ -339,20 +352,70 @@ impl Drop for FailedInstallGuard<'_> {
     }
 }
 
+fn stage_cask_artifacts(
+    extracted_root: &Path,
+    keg_path: &Path,
+    cask: &crate::installer::cask::ResolvedCask,
+) -> Result<(), Error> {
+    stage_cask_apps(extracted_root, keg_path, cask)?;
+    stage_cask_binaries(extracted_root, keg_path, cask)?;
+    Ok(())
+}
+
+fn stage_cask_apps(
+    extracted_root: &Path,
+    keg_path: &Path,
+    cask: &crate::installer::cask::ResolvedCask,
+) -> Result<(), Error> {
+    let apps_dir = keg_path.join(CASK_APPS_DIR);
+    if cask.apps.is_empty() {
+        return Ok(());
+    }
+
+    fs::create_dir_all(&apps_dir).map_err(Error::store("failed to create cask app dir"))?;
+
+    for app in &cask.apps {
+        let source = resolve_relative_cask_path(extracted_root, cask, &app.source, "app")?;
+        if !source.exists() {
+            return Err(Error::InvalidArgument {
+                message: format!(
+                    "cask '{}' app source '{}' not found in archive",
+                    cask.token, app.source
+                ),
+            });
+        }
+
+        let target = apps_dir.join(&app.target);
+        if target.symlink_metadata().is_ok() {
+            remove_path_any(&target)
+                .map_err(Error::store("failed to replace existing cask app"))?;
+        }
+
+        copy_path_recursive(&source, &target)?;
+    }
+
+    Ok(())
+}
+
 fn stage_cask_binaries(
     extracted_root: &Path,
     keg_path: &Path,
     cask: &crate::installer::cask::ResolvedCask,
 ) -> Result<(), Error> {
+    if cask.binaries.is_empty() {
+        return Ok(());
+    }
+
     let bin_dir = keg_path.join("bin");
     fs::create_dir_all(&bin_dir).map_err(Error::store("failed to create cask bin dir"))?;
 
     for binary in &cask.binaries {
-        let source = resolve_cask_source_path(extracted_root, cask, &binary.source)?;
+        let source =
+            resolve_cask_binary_source_path(extracted_root, keg_path, cask, &binary.source)?;
         if !source.exists() {
             return Err(Error::InvalidArgument {
                 message: format!(
-                    "cask '{}' binary source '{}' not found in archive",
+                    "cask '{}' binary source '{}' not found",
                     cask.token, binary.source
                 ),
             });
@@ -390,12 +453,11 @@ fn stage_raw_cask_binary(
     keg_path: &Path,
     cask: &crate::installer::cask::ResolvedCask,
 ) -> Result<(), Error> {
-    if cask.binaries.len() != 1 {
+    if !cask.apps.is_empty() || cask.binaries.len() != 1 {
         return Err(Error::InvalidArgument {
             message: format!(
-                "cask '{}' has {} binary artifacts but the download is a raw binary; expected exactly 1",
+                "cask '{}' has unsupported raw download layout; expected exactly 1 binary artifact and no app artifacts",
                 cask.token,
-                cask.binaries.len()
             ),
         });
     }
@@ -423,20 +485,28 @@ fn stage_raw_cask_binary(
     Ok(())
 }
 
-fn resolve_cask_source_path(
+fn resolve_cask_binary_source_path(
     extracted_root: &Path,
+    keg_path: &Path,
     cask: &crate::installer::cask::ResolvedCask,
     source: &str,
-) -> Result<std::path::PathBuf, Error> {
+) -> Result<PathBuf, Error> {
     if source.starts_with("$APPDIR") {
-        return Err(Error::InvalidArgument {
-            message: format!(
-                "cask '{}' uses APPDIR artifacts which are not supported yet",
-                cask.token
-            ),
-        });
+        let relative = source
+            .trim_start_matches("$APPDIR/")
+            .trim_start_matches("$APPDIR");
+        return resolve_relative_cask_path(&keg_path.join(CASK_APPS_DIR), cask, relative, "binary");
     }
 
+    resolve_relative_cask_path(extracted_root, cask, source, "binary")
+}
+
+fn resolve_relative_cask_path(
+    root: &Path,
+    cask: &crate::installer::cask::ResolvedCask,
+    source: &str,
+    artifact_kind: &str,
+) -> Result<PathBuf, Error> {
     let mut normalized = source.to_string();
     let caskroom_prefix = format!("$HOMEBREW_PREFIX/Caskroom/{}/{}/", cask.token, cask.version);
     if let Some(stripped) = normalized.strip_prefix(&caskroom_prefix) {
@@ -447,8 +517,8 @@ fn resolve_cask_source_path(
     if source_path.is_absolute() {
         return Err(Error::InvalidArgument {
             message: format!(
-                "cask '{}' binary source '{}' must be a relative path",
-                cask.token, source
+                "cask '{}' {artifact_kind} source '{}' must be a relative path",
+                cask.token, source,
             ),
         });
     }
@@ -457,14 +527,172 @@ fn resolve_cask_source_path(
         if matches!(component, std::path::Component::ParentDir) {
             return Err(Error::InvalidArgument {
                 message: format!(
-                    "cask '{}' binary source '{}' cannot contain '..'",
-                    cask.token, source
+                    "cask '{}' {artifact_kind} source '{}' cannot contain '..'",
+                    cask.token, source,
                 ),
             });
         }
     }
 
-    Ok(extracted_root.join(source_path))
+    Ok(root.join(source_path))
+}
+
+fn link_cask_apps(
+    keg_path: &Path,
+    app_dir: &Path,
+    cask: &crate::installer::cask::ResolvedCask,
+) -> Result<Vec<crate::cellar::link::LinkedFile>, Error> {
+    if cask.apps.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    fs::create_dir_all(app_dir).map_err(Error::store("failed to create app directory"))?;
+    let staged_apps_dir = keg_path.join(CASK_APPS_DIR);
+    let mut installed_targets = Vec::new();
+
+    let result = (|| -> Result<(), Error> {
+        for app in &cask.apps {
+            let source = staged_apps_dir.join(&app.target);
+            let target = app_dir.join(&app.target);
+
+            if !source.exists() {
+                return Err(Error::InvalidArgument {
+                    message: format!(
+                        "cask '{}' app '{}' was not staged correctly",
+                        cask.token, app.target
+                    ),
+                });
+            }
+
+            if source.symlink_metadata().is_ok()
+                && source.is_symlink()
+                && target.exists()
+                && let Ok(existing) = fs::read_link(&source)
+            {
+                let resolved = if existing.is_relative() {
+                    source.parent().unwrap_or(Path::new("")).join(existing)
+                } else {
+                    existing
+                };
+                if fs::canonicalize(&resolved).ok() == fs::canonicalize(&target).ok() {
+                    continue;
+                }
+            }
+
+            if target.symlink_metadata().is_ok() || target.exists() {
+                return Err(Error::LinkConflict {
+                    conflicts: vec![zb_core::ConflictedLink {
+                        path: target,
+                        owned_by: None,
+                    }],
+                });
+            }
+
+            move_cask_app_to_target(&source, &target)?;
+            installed_targets.push(target);
+        }
+
+        Ok(())
+    })();
+
+    if result.is_err() {
+        for target in &installed_targets {
+            let _ = remove_path_any(target);
+        }
+    }
+
+    result?;
+
+    Ok(Vec::new())
+}
+
+fn copy_path_recursive(src: &Path, dst: &Path) -> Result<(), Error> {
+    let file_type =
+        fs::symlink_metadata(src).map_err(Error::store("failed to read source metadata"))?;
+
+    if file_type.file_type().is_symlink() {
+        let target = fs::read_link(src).map_err(Error::store("failed to read source symlink"))?;
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(target, dst)
+            .map_err(Error::store("failed to create symlink"))?;
+        #[cfg(not(unix))]
+        fs::copy(src, dst).map_err(Error::store("failed to copy symlink as file"))?;
+        return Ok(());
+    }
+
+    if file_type.is_dir() {
+        fs::create_dir_all(dst).map_err(Error::store("failed to create target directory"))?;
+        for entry in fs::read_dir(src).map_err(Error::store("failed to read source directory"))? {
+            let entry = entry.map_err(Error::store("failed to read source directory entry"))?;
+            copy_path_recursive(&entry.path(), &dst.join(entry.file_name()))?;
+        }
+        return Ok(());
+    }
+
+    fs::copy(src, dst).map_err(Error::store("failed to copy file"))?;
+    Ok(())
+}
+
+fn move_cask_app_to_target(source: &Path, target: &Path) -> Result<(), Error> {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)
+            .map_err(Error::store("failed to create app parent directory"))?;
+    }
+
+    match fs::rename(source, target) {
+        Ok(()) => {}
+        Err(_) => {
+            copy_path_recursive(source, target)?;
+            remove_path_any(source)
+                .map_err(Error::store("failed to remove staged app after copy"))?;
+        }
+    }
+
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(target, source)
+        .map_err(Error::store("failed to create staged app symlink"))?;
+
+    Ok(())
+}
+
+fn uninstall_cask_apps(keg_path: &Path) -> Result<(), Error> {
+    let apps_dir = keg_path.join(CASK_APPS_DIR);
+    if !apps_dir.exists() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(&apps_dir).map_err(Error::store("failed to read cask app dir"))? {
+        let entry = entry.map_err(Error::store("failed to read cask app entry"))?;
+        let staged_path = entry.path();
+        if !staged_path.is_symlink() {
+            continue;
+        }
+
+        let resolved = resolve_staged_cask_app_target(&staged_path)?;
+        if resolved.exists() {
+            remove_path_any(&resolved).map_err(Error::store("failed to remove installed app"))?;
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn resolve_staged_cask_app_target(staged_path: &Path) -> Result<PathBuf, Error> {
+    let target = fs::read_link(staged_path).map_err(Error::store("failed to read app symlink"))?;
+    Ok(if target.is_relative() {
+        staged_path.parent().unwrap_or(Path::new("")).join(target)
+    } else {
+        target
+    })
+}
+
+pub(super) fn remove_path_any(path: &Path) -> std::io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        fs::remove_file(path)
+    } else {
+        fs::remove_dir_all(path)
+    }
 }
 
 #[cfg(test)]
@@ -531,6 +759,7 @@ mod tests {
                 source: "claude".to_string(),
                 target: "claude".to_string(),
             }],
+            apps: vec![],
         };
 
         stage_raw_cask_binary(&blob_path, &keg_path, &cask).unwrap();
@@ -573,9 +802,84 @@ mod tests {
                     target: "b".to_string(),
                 },
             ],
+            apps: vec![],
         };
 
         let err = stage_raw_cask_binary(&blob_path, &keg_path, &cask).unwrap_err();
-        assert!(err.to_string().contains("raw binary"));
+        assert!(err.to_string().contains("unsupported raw download layout"));
+    }
+
+    #[test]
+    fn stage_cask_artifacts_copies_apps_and_appdir_binaries() {
+        let tmp = TempDir::new().unwrap();
+        let extracted_root = tmp.path().join("extract");
+        let app_dir = extracted_root.join("Test.app/Contents/MacOS");
+        fs::create_dir_all(&app_dir).unwrap();
+        fs::write(
+            extracted_root.join("Test.app/Contents/Info.plist"),
+            b"plist",
+        )
+        .unwrap();
+        fs::write(app_dir.join("test-cli"), b"#!/bin/sh\necho from-app").unwrap();
+
+        let keg_path = tmp.path().join("keg");
+        let cask = crate::installer::cask::ResolvedCask {
+            install_name: "cask:test".to_string(),
+            token: "test".to_string(),
+            version: "1.0.0".to_string(),
+            url: "https://example.com/test.zip".to_string(),
+            sha256: "ccc".to_string(),
+            binaries: vec![crate::installer::cask::CaskBinary {
+                source: "$APPDIR/Test.app/Contents/MacOS/test-cli".to_string(),
+                target: "test-cli".to_string(),
+            }],
+            apps: vec![crate::installer::cask::CaskApp {
+                source: "Test.app".to_string(),
+                target: "Test.app".to_string(),
+            }],
+        };
+
+        stage_cask_artifacts(&extracted_root, &keg_path, &cask).unwrap();
+
+        assert!(
+            keg_path
+                .join("Applications/Test.app/Contents/Info.plist")
+                .exists()
+        );
+        assert_eq!(
+            fs::read_to_string(keg_path.join("bin/test-cli")).unwrap(),
+            "#!/bin/sh\necho from-app"
+        );
+    }
+
+    #[test]
+    fn link_cask_apps_creates_symlink_in_app_dir() {
+        let tmp = TempDir::new().unwrap();
+        let keg_path = tmp.path().join("keg");
+        let staged_app = keg_path.join("Applications/Test.app");
+        fs::create_dir_all(staged_app.join("Contents")).unwrap();
+        fs::write(staged_app.join("Contents/Info.plist"), b"plist").unwrap();
+
+        let app_dir = tmp.path().join("Applications");
+        let cask = crate::installer::cask::ResolvedCask {
+            install_name: "cask:test".to_string(),
+            token: "test".to_string(),
+            version: "1.0.0".to_string(),
+            url: "https://example.com/test.zip".to_string(),
+            sha256: "ddd".to_string(),
+            binaries: vec![],
+            apps: vec![crate::installer::cask::CaskApp {
+                source: "Test.app".to_string(),
+                target: "Test.app".to_string(),
+            }],
+        };
+
+        let linked = link_cask_apps(&keg_path, &app_dir, &cask).unwrap();
+        assert!(linked.is_empty());
+        assert!(app_dir.join("Test.app/Contents/Info.plist").exists());
+        assert_eq!(
+            fs::read_link(&staged_app).unwrap(),
+            app_dir.join("Test.app")
+        );
     }
 }

--- a/zb_io/src/installer/install/mod.rs
+++ b/zb_io/src/installer/install/mod.rs
@@ -36,6 +36,7 @@ pub struct Installer {
     linker: Linker,
     pub(crate) db: Database,
     prefix: PathBuf,
+    app_dir: PathBuf,
     locks_dir: PathBuf,
 }
 
@@ -81,6 +82,24 @@ impl Installer {
         prefix: PathBuf,
         locks_dir: PathBuf,
     ) -> Self {
+        let app_dir = default_app_dir();
+        Self::new_with_app_dir(
+            api_client, blob_cache, store, cellar, linker, db, prefix, app_dir, locks_dir,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_app_dir(
+        api_client: ApiClient,
+        blob_cache: BlobCache,
+        store: Store,
+        cellar: Cellar,
+        linker: Linker,
+        db: Database,
+        prefix: PathBuf,
+        app_dir: PathBuf,
+        locks_dir: PathBuf,
+    ) -> Self {
         Self {
             api_client,
             downloader: ParallelDownloader::new(blob_cache),
@@ -89,8 +108,13 @@ impl Installer {
             linker,
             db,
             prefix,
+            app_dir,
             locks_dir,
         }
+    }
+
+    pub(crate) fn app_dir(&self) -> &Path {
+        &self.app_dir
     }
 
     pub fn clear_api_cache(&self) -> Result<usize, Error> {
@@ -274,6 +298,22 @@ impl Installer {
     }
 }
 
+fn default_app_dir() -> PathBuf {
+    if let Ok(path) = std::env::var("ZEROBREW_APPDIR") {
+        return PathBuf::from(path);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        PathBuf::from("/Applications")
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        PathBuf::from("/Applications")
+    }
+}
+
 pub fn create_installer(
     root: &Path,
     prefix: &Path,
@@ -336,6 +376,7 @@ pub fn create_installer(
         linker,
         db,
         prefix: prefix.to_path_buf(),
+        app_dir: default_app_dir(),
         locks_dir,
     })
 }


### PR DESCRIPTION
- [x] I have run all relevant linters for this PR.
- [x] I have read and will follow the contributing guidelines.

#

- [x] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [ ] I have not used AI for _any_ portion of this PR.

changes:
- adds `app` artifact parsing for casks in addition to existing `binary` artifacts
- stages app bundles into the keg under `Applications/`
- installs the real `.app` into `/Applications` and leaves the keg path as a symlink back to the installed app
- supports `$APPDIR/...` binary sources so app-bundled CLIs can still be linked from casks
- adds regression tests for app artifact parsing, app staging/linking, and app-bundled binary support

note:
- this is the base cask branch for follow-up PRs
- `.dmg` / `.pkg` casks are still out of scope for follow-up PRs

> AI-assisted: planning + initial implementation with gpt-5.4, manually reviewed and tested.
