### PR TITLE
chore(docs): add Homebrew tap as alternative install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 curl -fsSL https://zerobrew.rs/install | bash
 ```
 
+Or via Homebrew:
+
+```bash
+brew tap lucasgelfond/zerobrew && brew install zerobrew
+```
+
 After install, run the `export` command it prints (or restart your terminal).
 
 ## Quick start

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,6 +26,12 @@
 curl -fsSL https://zerobrew.rs/install | bash
 ```
 
+或通过 Homebrew 安装：
+
+```bash
+brew tap lucasgelfond/zerobrew && brew install zerobrew
+```
+
 安装完成后，运行它打印的 `export` 命令（或重启终端）。
 
 ## 快速开始 (Quick start)


### PR DESCRIPTION
- [x] I have run all relevant linters for this PR.
- [x] I have read and will follow the contributing guidelines.

#

- [x] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [ ] I have not used AI for _any_ portion of this PR.

## AI Usage

Claude Code was used to draft the README additions and open this PR. The install command (`brew tap lucasgelfond/zerobrew && brew install zerobrew`) was manually tested on my Macbook Air (macOS 26.3 / Homebrew 5.1.0-153-g894a3d2) and confirmed working before submitting.

## Description

Adds Homebrew tap install instructions to `README.md` and `README.zh.md` as an alternative to the curl-based installer.