### PR TITLE
feat(zb_cli): add --cask flag for cask installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ After install, run the `export` command it prints (or restart your terminal).
 ```bash
 zb install jq                   # install one package
 zb install wget git             # install multiple
+zb install --cask docker        # install a cask
 zb bundle                       # install from Brewfile
 zb bundle install -f myfile     # install from custom file
 zb bundle dump                  # export installed packages to Brewfile

--- a/zb_cli/src/bin/zb.rs
+++ b/zb_cli/src/bin/zb.rs
@@ -55,12 +55,14 @@ async fn run(cli: Cli) -> Result<(), zb_core::Error> {
         Commands::Completion { .. } => unreachable!(),
         Commands::Install {
             formulas,
+            cask,
             no_link,
             build_from_source,
         } => {
             commands::install::execute(
                 &mut installer,
                 formulas,
+                cask,
                 no_link,
                 build_from_source,
                 &mut ui,

--- a/zb_cli/src/cli.rs
+++ b/zb_cli/src/cli.rs
@@ -91,6 +91,18 @@ mod tests {
         let result = Cli::try_parse_from(["zb", "outdated", "--verbose", "--json"]);
         assert!(result.is_err());
     }
+
+    #[test]
+    fn install_accepts_cask_flag() {
+        let cli = Cli::try_parse_from(["zb", "install", "--cask", "docker-desktop"]).unwrap();
+        match cli.command {
+            super::Commands::Install { cask, formulas, .. } => {
+                assert!(cask);
+                assert_eq!(formulas, vec!["docker-desktop"]);
+            }
+            _ => panic!("expected install command"),
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -98,6 +110,8 @@ pub enum Commands {
     Install {
         #[arg(required = true, num_args = 1..)]
         formulas: Vec<String>,
+        #[arg(long, help = "Treat all arguments as casks")]
+        cask: bool,
         #[arg(long)]
         no_link: bool,
         #[arg(long, short = 's')]

--- a/zb_cli/src/commands/bundle.rs
+++ b/zb_cli/src/commands/bundle.rs
@@ -39,7 +39,7 @@ async fn install_from_file(
 
     let start = Instant::now();
     for formula in formulas {
-        install::execute(installer, vec![formula], no_link, false, ui).await?;
+        install::execute(installer, vec![formula], false, no_link, false, ui).await?;
     }
 
     println!(

--- a/zb_cli/src/commands/install.rs
+++ b/zb_cli/src/commands/install.rs
@@ -6,11 +6,12 @@ use std::time::Instant;
 use zb_io::{InstallProgress, ProgressCallback};
 
 use crate::ui::StdUi;
-use crate::utils::{normalize_formula_name, suggest_homebrew, suggest_missing_formula_matches};
+use crate::utils::{normalize_install_target, suggest_homebrew, suggest_missing_formula_matches};
 
 pub async fn execute(
     installer: &mut zb_io::Installer,
     formulas: Vec<String>,
+    cask: bool,
     no_link: bool,
     build_from_source: bool,
     ui: &mut StdUi,
@@ -25,7 +26,7 @@ pub async fn execute(
     let mut normalized_names = Vec::new();
     let mut cask_names = Vec::new();
     for formula in &formulas {
-        match normalize_formula_name(formula) {
+        match normalize_install_target(formula, cask) {
             Ok(name) => {
                 if name.starts_with("cask:") {
                     cask_names.push(name);
@@ -34,7 +35,7 @@ pub async fn execute(
                 }
             }
             Err(e) => {
-                suggest_homebrew(formula, &e);
+                suggest_homebrew(formula, cask, &e);
                 return Err(e);
             }
         }
@@ -53,7 +54,7 @@ pub async fn execute(
 
                 if !handled_missing {
                     for formula in &formulas {
-                        suggest_homebrew(formula, &e);
+                        suggest_homebrew(formula, cask, &e);
                     }
                 }
                 return Err(e);
@@ -219,7 +220,7 @@ pub async fn execute(
 
                 if !handled_missing {
                     for formula in &formulas {
-                        suggest_homebrew(formula, &e);
+                        suggest_homebrew(formula, cask, &e);
                     }
                 }
                 return Err(e);

--- a/zb_cli/src/commands/migrate.rs
+++ b/zb_cli/src/commands/migrate.rs
@@ -87,6 +87,7 @@ pub async fn execute(
     crate::commands::install::execute(
         installer,
         formula_names.clone(),
+        false, // cask
         false, // no_link
         false, // build_from_source
         ui,

--- a/zb_cli/src/utils.rs
+++ b/zb_cli/src/utils.rs
@@ -34,6 +34,14 @@ pub fn normalize_formula_name(name: &str) -> Result<String, zb_core::Error> {
     Ok(trimmed.to_string())
 }
 
+pub fn normalize_install_target(name: &str, cask: bool) -> Result<String, zb_core::Error> {
+    let normalized = normalize_formula_name(name)?;
+    if cask && !normalized.starts_with("cask:") {
+        return Ok(format!("cask:{normalized}"));
+    }
+    Ok(normalized)
+}
+
 pub fn format_formula_suggestions(requested: &str, suggestions: &[String]) -> Option<String> {
     if suggestions.is_empty() {
         return None;
@@ -82,7 +90,15 @@ pub async fn suggest_missing_formula_matches(
     false
 }
 
-pub fn suggest_homebrew(formula: &str, error: &zb_core::Error) {
+pub fn suggest_homebrew(formula: &str, cask: bool, error: &zb_core::Error) {
+    let brew_target =
+        normalize_install_target(formula, cask).unwrap_or_else(|_| formula.to_string());
+    let brew_command = if let Some(cask_name) = brew_target.strip_prefix("cask:") {
+        format!("brew install --cask {}", cask_name)
+    } else {
+        format!("brew install {}", formula)
+    };
+
     eprintln!();
     eprintln!(
         "{} This package can't be installed with zerobrew.",
@@ -110,10 +126,7 @@ pub fn suggest_homebrew(formula: &str, error: &zb_core::Error) {
         );
     } else {
         eprintln!("      Try installing with Homebrew instead:");
-        eprintln!(
-            "      {}",
-            style(format!("brew install {}", formula)).cyan()
-        );
+        eprintln!("      {}", style(brew_command).cyan());
     }
 
     eprintln!();
@@ -161,7 +174,8 @@ mod tests {
     use zb_io::{Installer, Linker};
 
     use super::{
-        format_formula_suggestions, normalize_formula_name, suggest_missing_formula_matches,
+        format_formula_suggestions, normalize_formula_name, normalize_install_target,
+        suggest_missing_formula_matches,
     };
 
     #[test]
@@ -184,6 +198,22 @@ mod tests {
     fn normalize_homebrew_cask_prefixes_token() {
         assert_eq!(
             normalize_formula_name("homebrew/cask/docker-desktop").unwrap(),
+            "cask:docker-desktop".to_string()
+        );
+    }
+
+    #[test]
+    fn normalize_install_target_prefixes_cask_flag() {
+        assert_eq!(
+            normalize_install_target("docker-desktop", true).unwrap(),
+            "cask:docker-desktop".to_string()
+        );
+    }
+
+    #[test]
+    fn normalize_install_target_keeps_existing_cask_token() {
+        assert_eq!(
+            normalize_install_target("cask:docker-desktop", true).unwrap(),
             "cask:docker-desktop".to_string()
         );
     }


### PR DESCRIPTION
- [x] I have run all relevant linters for this PR.
- [x] I have read and will follow the contributing guidelines.

#

- [x] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [ ] I have not used AI for _any_ portion of this PR.

adds a `--cask` flag to `zb install` so cask installs can be invoked with the same homebrew syntax instead of requiring the internal `cask:` prefix.

changes:
- adds `--cask` to `zb install`
- maps `zb install --cask <token>` to the existing internal `cask:<token>` install path
- keeps existing support for `homebrew/cask/<token>` and `cask:<token>`
- updates Homebrew fallback suggestions to print `brew install --cask ...` for cask requests
- updates install call sites that reuse the shared install command
- adds parser/normalization tests for the new flag
- adds a README example for `zb install --cask docker`

> AI-assisted: planning & implementation were done with GPT-5.4, then manually checked and tested.
