### PR TITLE
ci: pin Ubuntu runners to 22.04 for stability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,12 @@ jobs:
             zbx_artifact_name: zbx-darwin-x64
 
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact_name: zb-linux-x64
             zbx_artifact_name: zbx-linux-x64
 
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04
             artifact_name: zb-linux-arm64
             zbx_artifact_name: zbx-linux-arm64
 
@@ -102,7 +102,7 @@ jobs:
   release:
     name: Create GitHub Release
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
## Summary

Pins Ubuntu runners in `.github/workflows/release.yml` from `ubuntu-latest`/`ubuntu-24.04-arm` to `ubuntu-22.04` to prevent CI breakage when Ubuntu moves to a new version.

## Changes

- `build` job (x86_64-linux): `ubuntu-latest` → `ubuntu-22.04`
- `build` job (aarch64-linux): `ubuntu-24.04-arm` → `ubuntu-22.04`
- `release` job: `ubuntu-latest` → `ubuntu-22.04`

## Motivation

Using `ubuntu-latest` is a CI stability risk — it can shift unexpectedly causing build failures. Pinning to `ubuntu-22.04` ensures consistent, stable CI behavior.
