### PR TITLE
feat(zb_cli): `zb upgrade` to upgrade installed packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `zb upgrade` command to upgrade installed packages, with `--build-from-source` and `--no-link` flags; supports upgrading all outdated packages or specific ones by name
 - Chinese translation of the README ([#315](https://github.com/lucasgelfond/zerobrew/pull/316))
 - Regex matches on `/Cellar/<pkg>/)([^/]+)(/)`, so it only matches version segments within Cellar-style paths ([#317](https://github.com/lucasgelfond/zerobrew/pull/317))
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ zb bundle install -f myfile     # install from custom file
 zb bundle dump                  # export installed packages to Brewfile
 zb bundle dump -f out --force   # dump to custom file (overwrite)
 zb uninstall jq                 # uninstall one package
+zb outdated                     # list packages with newer versions
+zb upgrade                      # upgrade all outdated packages
+zb upgrade jq wget              # upgrade specific packages
 zb reset                        # uninstall everything
 zb gc                           # garbage collect unused store entries
 zbx jq --version                # run without linking

--- a/README.zh.md
+++ b/README.zh.md
@@ -44,6 +44,9 @@ zb bundle install -f myfile     # 从自定义文件安装
 zb bundle dump                  # 将已安装的软件包导出到 Brewfile
 zb bundle dump -f out --force   # 导出到自定义文件（覆盖）
 zb uninstall jq                 # 卸载单个软件包
+zb outdated                     # 列出有新版本可用的软件包
+zb upgrade                      # 升级所有已过期的软件包
+zb upgrade jq wget              # 升级指定的软件包
 zb reset                        # 卸载所有内容
 zb gc                           # 垃圾回收未使用的存储条目
 zbx jq --version                # 在不链接的情况下运行

--- a/zb_cli/src/bin/zb.rs
+++ b/zb_cli/src/bin/zb.rs
@@ -84,6 +84,20 @@ async fn run(cli: Cli) -> Result<(), zb_core::Error> {
         Commands::Outdated { json } => {
             commands::outdated::execute(&mut installer, cli.quiet, cli.verbose > 0, json).await
         }
+        Commands::Upgrade {
+            formulas,
+            build_from_source,
+            no_link,
+        } => {
+            commands::upgrade::execute(
+                &mut installer,
+                formulas,
+                build_from_source,
+                no_link,
+                &mut ui,
+            )
+            .await
+        }
         Commands::Reset { yes } => commands::reset::execute(&root, &prefix, yes, &mut ui),
         Commands::Run { formula, args } => {
             commands::run::execute(&mut installer, formula, args).await

--- a/zb_cli/src/cli.rs
+++ b/zb_cli/src/cli.rs
@@ -181,6 +181,15 @@ pub enum Commands {
         #[arg(long, conflicts_with_all = ["quiet", "verbose"], help = "Output as JSON")]
         json: bool,
     },
+    /// Upgrade installed packages to the latest versions
+    Upgrade {
+        #[arg(required = false, num_args = 0..)]
+        formulas: Vec<String>,
+        #[arg(long, short = 's', help = "Build from source instead of using bottles")]
+        build_from_source: bool,
+        #[arg(long, help = "Do not create symlinks after installation")]
+        no_link: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/zb_cli/src/commands/mod.rs
+++ b/zb_cli/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod reset;
 pub mod run;
 pub mod uninstall;
 pub mod update;
+pub mod upgrade;

--- a/zb_cli/src/commands/upgrade.rs
+++ b/zb_cli/src/commands/upgrade.rs
@@ -1,0 +1,220 @@
+use console::style;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use zb_io::{InstallProgress, ProgressCallback};
+
+use crate::ui::StdUi;
+use crate::utils::normalize_formula_name;
+
+pub async fn execute(
+    installer: &mut zb_io::Installer,
+    formulas: Vec<String>,
+    build_from_source: bool,
+    no_link: bool,
+    ui: &mut StdUi,
+) -> Result<(), zb_core::Error> {
+    let start = Instant::now();
+
+    let outdated = if formulas.is_empty() {
+        ui.heading("Checking for outdated packages...".to_string())
+            .map_err(ui_error)?;
+        let (outdated, warnings) = installer.check_outdated().await?;
+        for warning in &warnings {
+            eprintln!("{} {}", style("Warning:").yellow().bold(), warning);
+        }
+        if outdated.is_empty() {
+            ui.info("All packages are up to date.".to_string())
+                .map_err(ui_error)?;
+            return Ok(());
+        }
+        outdated
+    } else {
+        let mut normalized = Vec::with_capacity(formulas.len());
+        for formula in &formulas {
+            normalized.push(normalize_formula_name(formula)?);
+        }
+        let mut outdated = Vec::new();
+        for name in &normalized {
+            match installer.is_outdated(name).await {
+                Ok(Some(pkg)) => outdated.push(pkg),
+                Ok(None) => {
+                    ui.info(format!("{} is already up to date", name))
+                        .map_err(ui_error)?;
+                }
+                Err(zb_core::Error::NotInstalled { .. }) => {
+                    ui.error(format!("{} is not installed", name))
+                        .map_err(ui_error)?;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        if outdated.is_empty() {
+            ui.info("All specified packages are up to date.".to_string())
+                .map_err(ui_error)?;
+            return Ok(());
+        }
+        outdated
+    };
+
+    ui.heading(format!("Upgrading {}...", style(outdated.len()).bold()))
+        .map_err(ui_error)?;
+
+    let multi = MultiProgress::new();
+    let bars: Arc<Mutex<HashMap<String, ProgressBar>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    let spinner_style = ProgressStyle::default_spinner()
+        .template("    {prefix:<16} {spinner:.cyan} {msg}")
+        .unwrap()
+        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
+
+    let done_style = ProgressStyle::default_spinner()
+        .template("    {prefix:<16} {msg}")
+        .unwrap();
+
+    let bars_clone = bars.clone();
+    let multi_clone = multi.clone();
+    let spinner_style_clone = spinner_style.clone();
+    let done_style_clone = done_style.clone();
+
+    let progress_callback: Arc<ProgressCallback> = Arc::new(Box::new(move |event| {
+        let mut bars = bars_clone.lock().unwrap();
+        match event {
+            InstallProgress::DownloadStarted { name, total_bytes } => {
+                let pb = if let Some(total) = total_bytes {
+                    let pb = multi_clone.add(ProgressBar::new(total));
+                    pb.set_style(
+                        ProgressStyle::default_bar()
+                            .template("    {prefix:<16} {bar:25.cyan/dim} {bytes:>10}/{total_bytes:<10} {eta:>6}")
+                            .unwrap()
+                            .progress_chars("━━╸"),
+                    );
+                    pb
+                } else {
+                    let pb = multi_clone.add(ProgressBar::new_spinner());
+                    pb.set_style(spinner_style_clone.clone());
+                    pb.set_message("downloading...");
+                    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+                    pb
+                };
+                pb.set_prefix(name.clone());
+                bars.insert(name, pb);
+            }
+            InstallProgress::DownloadProgress {
+                name,
+                downloaded,
+                total_bytes,
+            } => {
+                if let Some(pb) = bars.get(&name)
+                    && total_bytes.is_some()
+                {
+                    pb.set_position(downloaded);
+                }
+            }
+            InstallProgress::DownloadCompleted { name, total_bytes } => {
+                if let Some(pb) = bars.get(&name) {
+                    if total_bytes > 0 {
+                        pb.set_position(total_bytes);
+                    }
+                    pb.set_style(spinner_style_clone.clone());
+                    pb.set_message("unpacking...");
+                    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+                }
+            }
+            InstallProgress::UnpackStarted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message("unpacking...");
+                }
+            }
+            InstallProgress::UnpackCompleted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message("unpacked");
+                }
+            }
+            InstallProgress::LinkStarted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message("linking...");
+                }
+            }
+            InstallProgress::LinkCompleted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message("linked");
+                }
+            }
+            InstallProgress::LinkSkipped { name, reason } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message(format!("keg-only ({})", reason));
+                }
+            }
+            InstallProgress::InstallCompleted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_style(done_style_clone.clone());
+                    pb.set_message(format!("{} upgraded", style("✓").green()));
+                    pb.finish();
+                }
+            }
+        }
+    }));
+
+    let mut upgraded = 0usize;
+    let mut errors: Vec<(String, zb_core::Error)> = Vec::new();
+
+    for pkg in &outdated {
+        let name = &pkg.name;
+        ui.step_start(name).map_err(ui_error)?;
+
+        match installer
+            .upgrade(
+                name,
+                build_from_source,
+                !no_link,
+                Some(progress_callback.clone()),
+            )
+            .await
+        {
+            Ok(()) => {
+                ui.step_ok().map_err(ui_error)?;
+                upgraded += 1;
+            }
+            Err(e) => {
+                ui.step_fail().map_err(ui_error)?;
+                errors.push((name.clone(), e));
+            }
+        }
+    }
+
+    {
+        let bars = bars.lock().unwrap();
+        for (_, pb) in bars.iter() {
+            if !pb.is_finished() {
+                pb.finish();
+            }
+        }
+    }
+
+    let elapsed = start.elapsed();
+    ui.blank_line().map_err(ui_error)?;
+
+    if errors.is_empty() {
+        ui.heading(format!(
+            "Upgraded {} packages in {:.2}s",
+            style(upgraded).green().bold(),
+            elapsed.as_secs_f64()
+        ))
+        .map_err(ui_error)?;
+        Ok(())
+    } else {
+        for (name, err) in &errors {
+            ui.error(format!("Failed to upgrade {}: {}", style(name).bold(), err))
+                .map_err(ui_error)?;
+        }
+        Err(errors.remove(0).1)
+    }
+}
+
+fn ui_error(err: std::io::Error) -> zb_core::Error {
+    zb_core::Error::FileError {
+        message: format!("failed to write CLI output: {err}"),
+    }
+}

--- a/zb_cli/src/commands/upgrade.rs
+++ b/zb_cli/src/commands/upgrade.rs
@@ -17,6 +17,10 @@ pub async fn execute(
 ) -> Result<(), zb_core::Error> {
     let start = Instant::now();
 
+    // Reported at the end so explicit-arg upgrades still run; we exit
+    // non-zero afterwards rather than discard partial progress.
+    let mut missing: Vec<String> = Vec::new();
+
     let outdated = if formulas.is_empty() {
         ui.heading("Checking for outdated packages...".to_string())
             .map_err(ui_error)?;
@@ -46,11 +50,15 @@ pub async fn execute(
                 Err(zb_core::Error::NotInstalled { .. }) => {
                     ui.error(format!("{} is not installed", name))
                         .map_err(ui_error)?;
+                    missing.push(name.clone());
                 }
                 Err(e) => return Err(e),
             }
         }
         if outdated.is_empty() {
+            if let Some(name) = missing.into_iter().next() {
+                return Err(zb_core::Error::NotInstalled { name });
+            }
             ui.info("All specified packages are up to date.".to_string())
                 .map_err(ui_error)?;
             return Ok(());
@@ -196,7 +204,12 @@ pub async fn execute(
     let elapsed = start.elapsed();
     ui.blank_line().map_err(ui_error)?;
 
-    if errors.is_empty() {
+    for (name, err) in &errors {
+        ui.error(format!("Failed to upgrade {}: {}", style(name).bold(), err))
+            .map_err(ui_error)?;
+    }
+
+    if errors.is_empty() && missing.is_empty() {
         ui.heading(format!(
             "Upgraded {} packages in {:.2}s",
             style(upgraded).green().bold(),
@@ -204,12 +217,12 @@ pub async fn execute(
         ))
         .map_err(ui_error)?;
         Ok(())
-    } else {
-        for (name, err) in &errors {
-            ui.error(format!("Failed to upgrade {}: {}", style(name).bold(), err))
-                .map_err(ui_error)?;
-        }
+    } else if !errors.is_empty() {
         Err(errors.remove(0).1)
+    } else {
+        Err(zb_core::Error::NotInstalled {
+            name: missing.remove(0),
+        })
     }
 }
 

--- a/zb_io/src/installer/install/mod.rs
+++ b/zb_io/src/installer/install/mod.rs
@@ -4,6 +4,7 @@ mod outdated;
 mod plan;
 mod source;
 mod uninstall;
+mod upgrade;
 
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
@@ -27,6 +28,21 @@ use zb_core::{Error, Formula, InstallMethod};
 use bottle::dependency_cellar_path;
 
 const MAX_CORRUPTION_RETRIES: usize = 3;
+
+/// Acquire the cross-process install lock. The returned `File` must be kept
+/// alive (e.g. `let _lock = ...`) for the duration the lock should be held —
+/// dropping it releases the flock. Re-acquiring in the same process while the
+/// guard is alive would deadlock, so multi-step flows (e.g. `upgrade`) take
+/// the lock once and call the no-lock `execute_inner` directly.
+pub(crate) fn acquire_install_lock(locks_dir: &Path) -> Result<File, Error> {
+    let lock_path = locks_dir.join("install.lock");
+    let lock_file =
+        File::create(&lock_path).map_err(Error::store("failed to create install lock"))?;
+    lock_file
+        .lock_exclusive()
+        .map_err(Error::store("failed to acquire install lock"))?;
+    Ok(lock_file)
+}
 
 pub struct Installer {
     api_client: ApiClient,
@@ -107,14 +123,19 @@ impl Installer {
         link: bool,
         progress: Option<Arc<ProgressCallback>>,
     ) -> Result<ExecuteResult, Error> {
-        let lock_path = self.locks_dir.join("install.lock");
-        let lock_file =
-            File::create(&lock_path).map_err(Error::store("failed to create install lock"))?;
-        lock_file
-            .lock_exclusive()
-            .map_err(Error::store("failed to acquire install lock"))?;
-        let _lock = lock_file;
+        let _lock = acquire_install_lock(&self.locks_dir)?;
+        self.execute_inner(plan, link, progress).await
+    }
 
+    /// No-lock variant of `execute_with_progress`. Callers MUST already hold
+    /// the install lock — used by `upgrade` to compose uninstall + install
+    /// under a single lock acquisition.
+    pub(crate) async fn execute_inner(
+        &mut self,
+        plan: InstallPlan,
+        link: bool,
+        progress: Option<Arc<ProgressCallback>>,
+    ) -> Result<ExecuteResult, Error> {
         let report = |event: InstallProgress| {
             if let Some(ref cb) = progress {
                 cb(event);

--- a/zb_io/src/installer/install/mod.rs
+++ b/zb_io/src/installer/install/mod.rs
@@ -364,6 +364,10 @@ pub fn create_installer(
 #[cfg(test)]
 mod test_support {
     pub fn create_bottle_tarball(formula_name: &str) -> Vec<u8> {
+        create_bottle_tarball_with_version(formula_name, "1.0.0")
+    }
+
+    pub fn create_bottle_tarball_with_version(formula_name: &str, version: &str) -> Vec<u8> {
         use flate2::Compression;
         use flate2::write::GzEncoder;
         use std::io::Write;
@@ -371,15 +375,16 @@ mod test_support {
 
         let mut builder = Builder::new(Vec::new());
 
+        let content = format!("#!/bin/sh\necho {} v{}", formula_name, version);
+
         let mut header = tar::Header::new_gnu();
         header
-            .set_path(format!("{}/1.0.0/bin/{}", formula_name, formula_name))
+            .set_path(format!("{}/{}/bin/{}", formula_name, version, formula_name))
             .unwrap();
-        header.set_size(20);
+        header.set_size(content.len() as u64);
         header.set_mode(0o755);
         header.set_cksum();
 
-        let content = format!("#!/bin/sh\necho {}", formula_name);
         builder.append(&header, content.as_bytes()).unwrap();
 
         let tar_data = builder.into_inner().unwrap();

--- a/zb_io/src/installer/install/uninstall.rs
+++ b/zb_io/src/installer/install/uninstall.rs
@@ -7,9 +7,13 @@ impl Installer {
         let installed = self.db.get_installed(name).ok_or(Error::NotInstalled {
             name: name.to_string(),
         })?;
-        let keg_name = formula_token(&installed.name);
+        self.uninstall_by_version(name, &installed.version)
+    }
 
-        let keg_path = self.cellar.keg_path(keg_name, &installed.version);
+    pub fn uninstall_by_version(&mut self, name: &str, version: &str) -> Result<(), Error> {
+        let keg_name = formula_token(name);
+
+        let keg_path = self.cellar.keg_path(keg_name, version);
         self.linker.unlink_keg(&keg_path)?;
 
         {
@@ -18,7 +22,7 @@ impl Installer {
             tx.commit()?;
         }
 
-        self.cellar.remove_keg(keg_name, &installed.version)?;
+        self.cellar.remove_keg(keg_name, version)?;
 
         Ok(())
     }

--- a/zb_io/src/installer/install/upgrade.rs
+++ b/zb_io/src/installer/install/upgrade.rs
@@ -1,0 +1,335 @@
+use std::sync::Arc;
+
+use zb_core::Error;
+
+use super::{Installer, acquire_install_lock};
+use crate::progress::ProgressCallback;
+
+impl Installer {
+    /// Upgrade an installed package to its latest version.
+    ///
+    /// Flow: hold the install lock for the whole operation, snapshot the
+    /// currently-installed version, plan the new version, then **uninstall
+    /// the old version before installing the new one**. The uninstall-first
+    /// order matters: a fresh install would otherwise hit `LinkConflict` on
+    /// the old version's symlinks, and would leave the old cellar directory
+    /// behind on disk (the leak this method exists to fix).
+    ///
+    /// If the planner finds the package is already on the latest version
+    /// (`plan.items` is empty), this is a no-op that returns `Ok(())`.
+    pub async fn upgrade(
+        &mut self,
+        name: &str,
+        build_from_source: bool,
+        link: bool,
+        progress: Option<Arc<ProgressCallback>>,
+    ) -> Result<(), Error> {
+        // One lock for the entire flow — uninstall + install must not race
+        // with other zb processes touching the same package.
+        let _lock = acquire_install_lock(&self.locks_dir)?;
+
+        let old = self.db.get_installed(name).ok_or(Error::NotInstalled {
+            name: name.to_string(),
+        })?;
+
+        let plan = self
+            .plan_with_options(&[name.to_string()], build_from_source)
+            .await?;
+
+        // Empty plan = already on the latest version. No-op, keep installation.
+        if plan.items.is_empty() {
+            return Ok(());
+        }
+
+        // Clear old version first: unlinks symlinks, removes the keg directory,
+        // drops `installed_kegs` / `keg_files` rows, decrements `store_refs`.
+        // After this the new install path is unobstructed.
+        self.uninstall_by_version(name, &old.version)?;
+
+        // We already hold the lock, so call the no-lock variant.
+        self.execute_inner(plan, link, progress).await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::cellar::Cellar;
+    use crate::installer::install::test_support::*;
+    use crate::network::api::ApiClient;
+    use crate::storage::blob::BlobCache;
+    use crate::storage::db::Database;
+    use crate::storage::store::Store;
+    use crate::{Installer, Linker};
+
+    fn formula_json(mock_uri: &str, name: &str, version: &str, tag: &str, sha: &str) -> String {
+        format!(
+            r#"{{
+                "name": "{name}",
+                "versions": {{ "stable": "{version}" }},
+                "dependencies": [],
+                "bottle": {{
+                    "stable": {{
+                        "files": {{
+                            "{tag}": {{
+                                "url": "{mock_uri}/bottles/{name}-{version}.{tag}.bottle.tar.gz",
+                                "sha256": "{sha}"
+                            }}
+                        }}
+                    }}
+                }}
+            }}"#
+        )
+    }
+
+    fn make_installer(
+        root: &std::path::Path,
+        prefix: &std::path::Path,
+        mock_uri: &str,
+    ) -> Installer {
+        fs::create_dir_all(root.join("db")).unwrap();
+        let api_client = ApiClient::with_base_url(format!("{mock_uri}/formula")).unwrap();
+        let blob_cache = BlobCache::new(&root.join("cache")).unwrap();
+        let store = Store::new(root).unwrap();
+        let cellar = Cellar::new(root).unwrap();
+        let linker = Linker::new(prefix).unwrap();
+        let db = Database::open(&root.join("db/zb.sqlite3")).unwrap();
+        Installer::new(
+            api_client,
+            blob_cache,
+            store,
+            cellar,
+            linker,
+            db,
+            prefix.to_path_buf(),
+            root.join("locks"),
+        )
+    }
+
+    #[tokio::test]
+    async fn upgrade_replaces_old_version_and_cleans_up() {
+        let mock_server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let tag = get_test_bottle_tag();
+
+        let bottle = create_bottle_tarball("testpkg");
+        let sha = sha256_hex(&bottle);
+
+        Mock::given(method("GET"))
+            .and(path("/formula/testpkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json(
+                &mock_server.uri(),
+                "testpkg",
+                "1.0.0",
+                tag,
+                &sha,
+            )))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/bottles/testpkg-1.0.0.{tag}.bottle.tar.gz")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle.clone()))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/formula/testpkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json(
+                &mock_server.uri(),
+                "testpkg",
+                "2.0.0",
+                tag,
+                &sha,
+            )))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/bottles/testpkg-2.0.0.{tag}.bottle.tar.gz")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle))
+            .mount(&mock_server)
+            .await;
+
+        let root = tmp.path().join("zerobrew");
+        let prefix = tmp.path().join("homebrew");
+        let mut installer = make_installer(&root, &prefix, &mock_server.uri());
+
+        installer
+            .install(&["testpkg".to_string()], true)
+            .await
+            .unwrap();
+        assert!(root.join("cellar/testpkg/1.0.0").exists());
+        assert!(prefix.join("bin/testpkg").exists());
+
+        installer
+            .upgrade("testpkg", false, true, None)
+            .await
+            .unwrap();
+
+        assert!(root.join("cellar/testpkg/2.0.0").exists());
+        assert!(
+            !root.join("cellar/testpkg/1.0.0").exists(),
+            "old cellar dir must be removed"
+        );
+
+        let bin_link = prefix.join("bin/testpkg");
+        assert!(bin_link.exists(), "new version must be linked");
+        let target = fs::read_link(&bin_link).unwrap();
+        let target_str = target.to_string_lossy();
+        assert!(
+            target_str.contains("2.0.0"),
+            "symlink must point at 2.0.0, got {target_str}"
+        );
+        assert!(
+            !target_str.contains("1.0.0"),
+            "symlink must not point at 1.0.0"
+        );
+
+        let installed = installer.get_installed("testpkg").unwrap();
+        assert_eq!(installed.version, "2.0.0");
+    }
+
+    #[tokio::test]
+    async fn upgrade_with_no_link_does_not_create_symlinks() {
+        let mock_server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let tag = get_test_bottle_tag();
+
+        let bottle = create_bottle_tarball("nolinkpkg");
+        let sha = sha256_hex(&bottle);
+
+        Mock::given(method("GET"))
+            .and(path("/formula/nolinkpkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json(
+                &mock_server.uri(),
+                "nolinkpkg",
+                "1.0.0",
+                tag,
+                &sha,
+            )))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/bottles/nolinkpkg-1.0.0.{tag}.bottle.tar.gz"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle.clone()))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/formula/nolinkpkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json(
+                &mock_server.uri(),
+                "nolinkpkg",
+                "2.0.0",
+                tag,
+                &sha,
+            )))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/bottles/nolinkpkg-2.0.0.{tag}.bottle.tar.gz"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle))
+            .mount(&mock_server)
+            .await;
+
+        let root = tmp.path().join("zerobrew");
+        let prefix = tmp.path().join("homebrew");
+        let mut installer = make_installer(&root, &prefix, &mock_server.uri());
+
+        installer
+            .install(&["nolinkpkg".to_string()], true)
+            .await
+            .unwrap();
+        assert!(prefix.join("bin/nolinkpkg").exists());
+
+        installer
+            .upgrade("nolinkpkg", false, false, None)
+            .await
+            .unwrap();
+
+        assert!(root.join("cellar/nolinkpkg/2.0.0").exists());
+        assert!(!root.join("cellar/nolinkpkg/1.0.0").exists());
+        assert!(
+            !prefix.join("bin/nolinkpkg").exists(),
+            "no symlinks expected when link=false"
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_no_op_when_already_latest() {
+        let mock_server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let tag = get_test_bottle_tag();
+
+        let bottle = create_bottle_tarball("steadypkg");
+        let sha = sha256_hex(&bottle);
+
+        Mock::given(method("GET"))
+            .and(path("/formula/steadypkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json(
+                &mock_server.uri(),
+                "steadypkg",
+                "1.0.0",
+                tag,
+                &sha,
+            )))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/bottles/steadypkg-1.0.0.{tag}.bottle.tar.gz"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        let root = tmp.path().join("zerobrew");
+        let prefix = tmp.path().join("homebrew");
+        let mut installer = make_installer(&root, &prefix, &mock_server.uri());
+
+        installer
+            .install(&["steadypkg".to_string()], true)
+            .await
+            .unwrap();
+
+        installer
+            .upgrade("steadypkg", false, true, None)
+            .await
+            .unwrap();
+
+        assert!(root.join("cellar/steadypkg/1.0.0").exists());
+        assert!(prefix.join("bin/steadypkg").exists());
+        assert_eq!(
+            installer.get_installed("steadypkg").unwrap().version,
+            "1.0.0"
+        );
+    }
+
+    #[tokio::test]
+    async fn upgrade_errors_when_not_installed() {
+        let mock_server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("zerobrew");
+        let prefix = tmp.path().join("homebrew");
+        let mut installer = make_installer(&root, &prefix, &mock_server.uri());
+
+        let err = installer
+            .upgrade("nonexistent", false, true, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, zb_core::Error::NotInstalled { .. }));
+    }
+}

--- a/zb_io/src/installer/install/upgrade.rs
+++ b/zb_io/src/installer/install/upgrade.rs
@@ -1,22 +1,26 @@
 use std::sync::Arc;
 
-use zb_core::Error;
+use zb_core::{Error, InstallMethod};
 
-use super::{Installer, acquire_install_lock};
-use crate::progress::ProgressCallback;
+use super::{InstallPlan, Installer, acquire_install_lock};
+use crate::network::download::{DownloadProgressCallback, DownloadRequest};
+use crate::progress::{InstallProgress, ProgressCallback};
 
 impl Installer {
     /// Upgrade an installed package to its latest version.
     ///
-    /// Flow: hold the install lock for the whole operation, snapshot the
-    /// currently-installed version, plan the new version, then **uninstall
-    /// the old version before installing the new one**. The uninstall-first
-    /// order matters: a fresh install would otherwise hit `LinkConflict` on
-    /// the old version's symlinks, and would leave the old cellar directory
-    /// behind on disk (the leak this method exists to fix).
+    /// Bottle artifacts for the new version are fetched into the blob cache
+    /// *before* the old keg is removed, so a download failure leaves the
+    /// existing installation intact. Source-built upgrades have no
+    /// equivalent pre-build stage and still go through uninstall-first.
     ///
-    /// If the planner finds the package is already on the latest version
-    /// (`plan.items` is empty), this is a no-op that returns `Ok(())`.
+    /// Uninstall-first on the link step is required either way: a fresh
+    /// install would hit `LinkConflict` on the old version's symlinks and
+    /// leave the old cellar directory behind on disk (the leak this method
+    /// exists to fix).
+    ///
+    /// Returns `Ok(())` when the package is already on its latest version,
+    /// `Error::NotInstalled` when there is no existing installation.
     pub async fn upgrade(
         &mut self,
         name: &str,
@@ -32,23 +36,64 @@ impl Installer {
             name: name.to_string(),
         })?;
 
+        // `plan_with_options` doesn't consult the installed DB, so an
+        // empty-plan check wouldn't fire on already-current packages.
+        if self.is_outdated(name).await?.is_none() {
+            return Ok(());
+        }
+
         let plan = self
             .plan_with_options(&[name.to_string()], build_from_source)
             .await?;
 
-        // Empty plan = already on the latest version. No-op, keep installation.
-        if plan.items.is_empty() {
-            return Ok(());
-        }
+        // Fetch new bottles before touching the old install — a download
+        // failure here leaves the existing keg intact.
+        self.prefetch_plan_bottles(&plan, progress.clone()).await?;
 
-        // Clear old version first: unlinks symlinks, removes the keg directory,
-        // drops `installed_kegs` / `keg_files` rows, decrements `store_refs`.
-        // After this the new install path is unobstructed.
         self.uninstall_by_version(name, &old.version)?;
 
         // We already hold the lock, so call the no-lock variant.
         self.execute_inner(plan, link, progress).await?;
 
+        Ok(())
+    }
+
+    /// Pre-download bottle artifacts in `plan` into the blob cache. No-op
+    /// for source-only plans.
+    async fn prefetch_plan_bottles(
+        &self,
+        plan: &InstallPlan,
+        progress: Option<Arc<ProgressCallback>>,
+    ) -> Result<(), Error> {
+        let requests: Vec<DownloadRequest> = plan
+            .items
+            .iter()
+            .filter_map(|item| match &item.method {
+                InstallMethod::Bottle(bottle) => Some(DownloadRequest {
+                    url: bottle.url.clone(),
+                    sha256: bottle.sha256.clone(),
+                    name: item.formula.name.clone(),
+                }),
+                _ => None,
+            })
+            .collect();
+
+        if requests.is_empty() {
+            return Ok(());
+        }
+
+        let download_progress: Option<DownloadProgressCallback> = progress.map(|cb| {
+            Arc::new(move |event: InstallProgress| {
+                cb(event);
+            }) as DownloadProgressCallback
+        });
+
+        let mut rx = self
+            .downloader
+            .download_streaming(requests, download_progress);
+        while let Some(result) = rx.recv().await {
+            result?;
+        }
         Ok(())
     }
 }
@@ -119,8 +164,10 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let tag = get_test_bottle_tag();
 
-        let bottle = create_bottle_tarball("testpkg");
-        let sha = sha256_hex(&bottle);
+        let bottle_v1 = create_bottle_tarball_with_version("testpkg", "1.0.0");
+        let sha_v1 = sha256_hex(&bottle_v1);
+        let bottle_v2 = create_bottle_tarball_with_version("testpkg", "2.0.0");
+        let sha_v2 = sha256_hex(&bottle_v2);
 
         Mock::given(method("GET"))
             .and(path("/formula/testpkg.json"))
@@ -129,14 +176,14 @@ mod tests {
                 "testpkg",
                 "1.0.0",
                 tag,
-                &sha,
+                &sha_v1,
             )))
             .up_to_n_times(1)
             .mount(&mock_server)
             .await;
         Mock::given(method("GET"))
             .and(path(format!("/bottles/testpkg-1.0.0.{tag}.bottle.tar.gz")))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle.clone()))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle_v1))
             .up_to_n_times(1)
             .mount(&mock_server)
             .await;
@@ -147,13 +194,13 @@ mod tests {
                 "testpkg",
                 "2.0.0",
                 tag,
-                &sha,
+                &sha_v2,
             )))
             .mount(&mock_server)
             .await;
         Mock::given(method("GET"))
             .and(path(format!("/bottles/testpkg-2.0.0.{tag}.bottle.tar.gz")))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle_v2))
             .mount(&mock_server)
             .await;
 
@@ -202,8 +249,10 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let tag = get_test_bottle_tag();
 
-        let bottle = create_bottle_tarball("nolinkpkg");
-        let sha = sha256_hex(&bottle);
+        let bottle_v1 = create_bottle_tarball_with_version("nolinkpkg", "1.0.0");
+        let sha_v1 = sha256_hex(&bottle_v1);
+        let bottle_v2 = create_bottle_tarball_with_version("nolinkpkg", "2.0.0");
+        let sha_v2 = sha256_hex(&bottle_v2);
 
         Mock::given(method("GET"))
             .and(path("/formula/nolinkpkg.json"))
@@ -212,7 +261,7 @@ mod tests {
                 "nolinkpkg",
                 "1.0.0",
                 tag,
-                &sha,
+                &sha_v1,
             )))
             .up_to_n_times(1)
             .mount(&mock_server)
@@ -221,7 +270,7 @@ mod tests {
             .and(path(format!(
                 "/bottles/nolinkpkg-1.0.0.{tag}.bottle.tar.gz"
             )))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle.clone()))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle_v1))
             .up_to_n_times(1)
             .mount(&mock_server)
             .await;
@@ -232,7 +281,7 @@ mod tests {
                 "nolinkpkg",
                 "2.0.0",
                 tag,
-                &sha,
+                &sha_v2,
             )))
             .mount(&mock_server)
             .await;
@@ -240,7 +289,7 @@ mod tests {
             .and(path(format!(
                 "/bottles/nolinkpkg-2.0.0.{tag}.bottle.tar.gz"
             )))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle_v2))
             .mount(&mock_server)
             .await;
 
@@ -331,5 +380,82 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, zb_core::Error::NotInstalled { .. }));
+    }
+
+    #[tokio::test]
+    async fn upgrade_keeps_old_version_when_new_bottle_download_fails() {
+        let mock_server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let tag = get_test_bottle_tag();
+
+        let bottle = create_bottle_tarball("flakypkg");
+        let sha = sha256_hex(&bottle);
+
+        Mock::given(method("GET"))
+            .and(path("/formula/flakypkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json(
+                &mock_server.uri(),
+                "flakypkg",
+                "1.0.0",
+                tag,
+                &sha,
+            )))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/bottles/flakypkg-1.0.0.{tag}.bottle.tar.gz")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+
+        // Plan resolves to 2.0.0 with a valid sha, but the bottle download
+        // returns 500 — exercise the pre-fetch failure path.
+        Mock::given(method("GET"))
+            .and(path("/formula/flakypkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json(
+                &mock_server.uri(),
+                "flakypkg",
+                "2.0.0",
+                tag,
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            )))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/bottles/flakypkg-2.0.0.{tag}.bottle.tar.gz")))
+            .respond_with(ResponseTemplate::new(500).set_body_string("download failed"))
+            .mount(&mock_server)
+            .await;
+
+        let root = tmp.path().join("zerobrew");
+        let prefix = tmp.path().join("homebrew");
+        let mut installer = make_installer(&root, &prefix, &mock_server.uri());
+
+        installer
+            .install(&["flakypkg".to_string()], true)
+            .await
+            .unwrap();
+        assert!(root.join("cellar/flakypkg/1.0.0").exists());
+        let bin_link = prefix.join("bin/flakypkg");
+        assert!(bin_link.exists());
+
+        let result = installer.upgrade("flakypkg", false, true, None).await;
+        assert!(result.is_err(), "upgrade should fail when bottle 500s");
+
+        assert!(
+            root.join("cellar/flakypkg/1.0.0").exists(),
+            "old cellar dir must be preserved on download failure"
+        );
+        assert!(
+            !root.join("cellar/flakypkg/2.0.0").exists(),
+            "no partial new cellar should exist"
+        );
+        assert!(bin_link.exists(), "symlink to old version must remain");
+        let target = fs::read_link(&bin_link).unwrap();
+        assert!(target.to_string_lossy().contains("1.0.0"));
+        let installed = installer.get_installed("flakypkg").unwrap();
+        assert_eq!(installed.version, "1.0.0");
     }
 }


### PR DESCRIPTION

  - [x] I have run all relevant linters for this PR.
  - [x] I have read and will follow the contributing guidelines.

  # `zb upgrade`

  Adds the `zb upgrade` command and fixes a disk-leak bug in its underlying flow.

  ## What's new

  - **`zb upgrade [<formula>...]`** — upgrades installed packages. With no args, upgrades everything `zb outdated` would list; with args, upgrades only those.
  - **Flags**: `-s, --build-from-source` (forces source build, matching `zb install`), `--no-link` (skip symlinks).
  - Behavior on already-latest packages is a no-op (does not error).

  ## What's fixed

  The earlier in-tree `Installer::upgrade` implementation installed the new version but never removed the old version's `cellar/<pkg>/<old>/` directory or its `keg_files` rows. Repeated upgrades would
  accumulate orphan keg directories on disk until manual cleanup.

  The fix reorders the flow to **uninstall the old version first, then install the new one**, reusing the existing `uninstall_by_version` helper so all three cleanup steps (unlink symlinks, drop DB
  rows, decrement `store_refs`, remove cellar dir) happen as one unit. The whole operation runs under a single `install.lock` acquisition (a small split of `execute_with_progress` into a locked outer /
  inner pair makes this composable without re-entrant flock deadlock).

  ## Changes by commit

  | Commit | Purpose |
  |---|---|
  | `refactor(zb_io): drop unused link helpers and dedupe uninstall` | Removes dead `unlink_only` / `relink_only`; makes `uninstall` a thin wrapper over `uninstall_by_version` |
  | `fix(zb_io): clean up old cellar and \`keg_files\` rows on \`zb upgrade\`` | The actual bug fix: rewrites `Installer::upgrade` into its own module, holds `install.lock` across the full flow, calls
  `uninstall_by_version` before `execute_inner` |
  | `feat(zb_cli): \`zb upgrade\` to upgrade installed packages` | CLI plumbing — `Commands::Upgrade`, `commands/upgrade.rs`, dispatch |
  | `docs: document \`zb upgrade\` in README and CHANGELOG` | README quick-start entries (EN + zh) + CHANGELOG entry |

  ## Out of scope

  - **Cask upgrade** is not implemented; cask upgrade has no existing path in the codebase and adding one is a separate change. Passing a cask to `zb upgrade` falls through to the existing
  `plan_with_options` error path.
  - **Progress callback factory** between `install` and `upgrade` UI flows is not extracted; both keep their own inline `MultiProgress` setup for now. Reasonable to revisit once a third call site
  appears.

  ## Test plan

  - [x] `just build` clean (fmt-check → clippy → build)
  - [x] `just test` — 333 / 0

  ## Test plan

  - [x] `just build` clean (fmt-check → clippy → build)
  - [x] `just test` — 333 / 0
  - [x] Four new tests in `zb_io/src/installer/install/upgrade.rs`:
    - `upgrade_replaces_old_version_and_cleans_up` — asserts new cellar exists, **old cellar dir is gone**, symlink points at new version, DB version is updated
    - `upgrade_with_no_link_does_not_create_symlinks` — verifies `--no-link` semantics
    - `upgrade_no_op_when_already_latest` — idempotent when nothing to do
    - `upgrade_errors_when_not_installed` — surfaces `Error::NotInstalled`
  - [x] Existing `uninstall` tests (`uninstall_cleans_everything`, `uninstall_accepts_full_tap_reference_after_install`, `uninstalling_non_installed_tap_ref_does_not_remove_core_formula`) still pass —
  regression coverage for the dedup.

  #

  <!--
  If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add
   a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
  -->

  - [x] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be
  closed, even without explanation.
  - [ ] I have not used AI for _any_ portion of this PR.

  ### AI usage disclosure

  Claude Code (Opus 4.7) was used as a pair-programming assistant for this PR. Specifically:

  - **Code review of an in-progress WIP** identified the cellar-leak bug and three pieces of unused helper code; surfaced the missing lock coverage and the structural mis-fit of the original
  implementation living in `mod.rs`.
  - **Implementation** of `zb_io/src/installer/install/upgrade.rs` (the new `Installer::upgrade` plus its 4 tests), the `execute_with_progress` / `execute_inner` split, and the `uninstall` dedupe
  refactor.
  - **Documentation** updates to `README.md` / `README.zh.md` / `CHANGELOG.md`.

  All design decisions (cleanup strategy: reuse `uninstall_by_version`; deferring cask upgrade and the shared progress-callback helper to follow-up work; commit-split granularity) were made by me after
  evaluating options the assistant proposed. Every change was manually reviewed and the test suite was run locally before each commit.