### PR TITLE
fix(zb_cli): ignore stale macOS prefix env default

### DIFF
--- a/zb_cli/src/bin/zb.rs
+++ b/zb_cli/src/bin/zb.rs
@@ -6,7 +6,7 @@ use zb_cli::{
     init::ensure_init,
     logging,
     ui::Ui,
-    utils::get_root_path,
+    utils::{get_prefix_path, get_root_path},
 };
 use zb_io::create_installer;
 
@@ -29,16 +29,7 @@ async fn run(cli: Cli) -> Result<(), zb_core::Error> {
     }
 
     let root = get_root_path(cli.root);
-    let prefix = cli.prefix.unwrap_or_else(|| {
-        // On macOS, Mach-O binaries have fixed-size path fields so the prefix
-        // must be no longer than the original Homebrew prefix (/opt/homebrew = 13 chars).
-        // Using root directly (/opt/zerobrew = 13 chars) keeps us within that limit.
-        if cfg!(target_os = "macos") {
-            root.clone()
-        } else {
-            root.join("prefix")
-        }
-    });
+    let prefix = get_prefix_path(cli.prefix, &root);
 
     if let Commands::Init { no_modify_path } = cli.command {
         return commands::init::execute(&root, &prefix, no_modify_path, &mut ui);

--- a/zb_cli/src/cli.rs
+++ b/zb_cli/src/cli.rs
@@ -9,7 +9,10 @@ pub struct Cli {
     #[arg(long, env = "ZEROBREW_ROOT", help = "Path to zerobrew data directory")]
     pub root: Option<PathBuf>,
 
-    #[arg(long, env = "ZEROBREW_PREFIX", help = "Path to Homebrew-style prefix")]
+    #[arg(
+        long,
+        help = "Path to Homebrew-style prefix (overrides ZEROBREW_PREFIX)"
+    )]
     pub prefix: Option<PathBuf>,
 
     #[arg(

--- a/zb_cli/src/init.rs
+++ b/zb_cli/src/init.rs
@@ -74,8 +74,13 @@ pub fn run_init(
             ui.info("Path-sensitive packages (e.g. git, curl) will fail to install.")?;
             ui.info(format!(
                 "Consider a shorter prefix, e.g.: {}",
-                style("zb init <root> /opt/zerobrew").cyan(),
+                style(format!(
+                    "zb --root {} --prefix /opt/zerobrew init",
+                    root.display()
+                ))
+                .cyan(),
             ))?;
+            ui.info("If this came from old shell config, unset ZEROBREW_PREFIX and rerun init.")?;
             ui.blank_line()?;
         }
     }

--- a/zb_cli/src/utils.rs
+++ b/zb_cli/src/utils.rs
@@ -1,5 +1,5 @@
 use console::style;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use zb_io::Installer;
 
 pub fn normalize_formula_name(name: &str) -> Result<String, zb_core::Error> {
@@ -148,9 +148,41 @@ pub fn get_root_path(cli_root: Option<PathBuf>) -> PathBuf {
     }
 }
 
+pub fn get_prefix_path(cli_prefix: Option<PathBuf>, root: &Path) -> PathBuf {
+    if let Some(prefix) = cli_prefix {
+        return prefix;
+    }
+
+    let env_prefix = std::env::var_os("ZEROBREW_PREFIX").map(PathBuf::from);
+    get_prefix_path_for_os(env_prefix, root, cfg!(target_os = "macos"))
+}
+
+fn get_prefix_path_for_os(env_prefix: Option<PathBuf>, root: &Path, is_macos: bool) -> PathBuf {
+    if let Some(prefix) = env_prefix
+        && !(is_macos && is_legacy_macos_default_prefix(&prefix, root))
+    {
+        return prefix;
+    }
+
+    default_prefix_for_os(root, is_macos)
+}
+
+fn default_prefix_for_os(root: &Path, is_macos: bool) -> PathBuf {
+    if is_macos {
+        root.to_path_buf()
+    } else {
+        root.join("prefix")
+    }
+}
+
+fn is_legacy_macos_default_prefix(prefix: &Path, root: &Path) -> bool {
+    prefix == root.join("prefix")
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::path::PathBuf;
 
     use tempfile::TempDir;
     use wiremock::matchers::{method, path};
@@ -161,8 +193,58 @@ mod tests {
     use zb_io::{Installer, Linker};
 
     use super::{
-        format_formula_suggestions, normalize_formula_name, suggest_missing_formula_matches,
+        format_formula_suggestions, get_prefix_path_for_os, normalize_formula_name,
+        suggest_missing_formula_matches,
     };
+
+    #[test]
+    fn macos_default_prefix_is_root() {
+        let root = PathBuf::from("/opt/zerobrew");
+
+        assert_eq!(get_prefix_path_for_os(None, &root, true), root);
+    }
+
+    #[test]
+    fn linux_default_prefix_is_root_prefix() {
+        let root = PathBuf::from("/home/user/.local/share/zerobrew");
+
+        assert_eq!(
+            get_prefix_path_for_os(None, &root, false),
+            root.join("prefix")
+        );
+    }
+
+    #[test]
+    fn macos_ignores_legacy_root_prefix_env_default() {
+        let root = PathBuf::from("/opt/zerobrew");
+
+        assert_eq!(
+            get_prefix_path_for_os(Some(root.join("prefix")), &root, true),
+            root
+        );
+    }
+
+    #[test]
+    fn macos_keeps_custom_env_prefix() {
+        let root = PathBuf::from("/opt/zerobrew");
+        let custom = PathBuf::from("/zb");
+
+        assert_eq!(
+            get_prefix_path_for_os(Some(custom.clone()), &root, true),
+            custom
+        );
+    }
+
+    #[test]
+    fn linux_keeps_env_prefix() {
+        let root = PathBuf::from("/home/user/.local/share/zerobrew");
+        let env_prefix = PathBuf::from("/tmp/zb-prefix");
+
+        assert_eq!(
+            get_prefix_path_for_os(Some(env_prefix.clone()), &root, false),
+            env_prefix
+        );
+    }
 
     #[test]
     fn normalize_core_tap_formula() {


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [X] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

Treat $ZEROBREW_ROOT/prefix from old shell config as stale on macOS so it does not override the safe /opt/zerobrew default.

Keep explicit --prefix and custom ZEROBREW_PREFIX values working, move prefix resolution into a helper, and add unit coverage for macOS/Linux defaults and env override behavior.

Also fix the long-prefix init hint to use valid global flag ordering.

Fixes #342
