### PR TITLE
fix/linux: python bottle runtime

### DIFF
--- a/zb_core/src/build/plan.rs
+++ b/zb_core/src/build/plan.rs
@@ -47,7 +47,7 @@ impl BuildPlan {
             source_checksum: source.checksum.clone(),
             ruby_source_path: formula.ruby_source_path.clone(),
             build_dependencies: all_build_deps,
-            runtime_dependencies: formula.dependencies.clone(),
+            runtime_dependencies: formula.runtime_dependencies(),
             detected_system,
             prefix: prefix.to_path_buf(),
             cellar_path,

--- a/zb_core/src/formula/bottle.rs
+++ b/zb_core/src/formula/bottle.rs
@@ -106,10 +106,10 @@ fn select_bottle_with_version(
 
     #[cfg(target_os = "linux")]
     {
-        for preferred_tag in preferred_linux_bottle_tags() {
+        for &preferred_tag in preferred_linux_bottle_tags() {
             if let Some(file) = formula.bottle.stable.files.get(preferred_tag) {
                 return Ok(SelectedBottle {
-                    tag: (*preferred_tag).to_string(),
+                    tag: preferred_tag.to_string(),
                     url: file.url.clone(),
                     sha256: file.sha256.clone(),
                 });

--- a/zb_core/src/formula/bottle.rs
+++ b/zb_core/src/formula/bottle.rs
@@ -23,6 +23,16 @@ fn preferred_linux_bottle_tags() -> &'static [&'static str] {
     preferred_linux_bottle_tags_for_arch(std::env::consts::ARCH)
 }
 
+#[cfg(any(target_os = "linux", test))]
+fn is_compatible_linux_bottle_tag_for_arch(tag: &str, arch: &str) -> bool {
+    preferred_linux_bottle_tags_for_arch(arch).contains(&tag)
+}
+
+#[cfg(target_os = "linux")]
+fn is_compatible_linux_bottle_tag(tag: &str) -> bool {
+    is_compatible_linux_bottle_tag_for_arch(tag, std::env::consts::ARCH)
+}
+
 #[cfg(target_os = "macos")]
 pub fn macos_major_version() -> Option<u32> {
     let output = std::process::Command::new("sw_vers")
@@ -160,7 +170,7 @@ fn select_bottle_with_version(
 
     #[cfg(target_os = "linux")]
     for (tag, file) in &formula.bottle.stable.files {
-        if tag.contains("linux") {
+        if is_compatible_linux_bottle_tag(tag) {
             return Ok(SelectedBottle {
                 tag: tag.clone(),
                 url: file.url.clone(),
@@ -241,6 +251,18 @@ mod tests {
             preferred_linux_bottle_tags_for_arch("x86_64"),
             &["x86_64_linux"]
         );
+    }
+
+    #[test]
+    fn linux_fallback_rejects_cross_arch_bottle_tags() {
+        assert!(!is_compatible_linux_bottle_tag_for_arch(
+            "x86_64_linux",
+            "aarch64"
+        ));
+        assert!(!is_compatible_linux_bottle_tag_for_arch(
+            "arm64_linux",
+            "x86_64"
+        ));
     }
 
     #[test]

--- a/zb_core/src/formula/bottle.rs
+++ b/zb_core/src/formula/bottle.rs
@@ -9,6 +9,20 @@ pub struct SelectedBottle {
 
 const MACOS_CODENAMES_NEWEST_FIRST: &[&str] = &["tahoe", "sequoia", "sonoma", "ventura"];
 
+#[cfg(any(target_os = "linux", test))]
+fn preferred_linux_bottle_tags_for_arch(arch: &str) -> &'static [&'static str] {
+    match arch {
+        "aarch64" => &["arm64_linux", "aarch64_linux"],
+        "x86_64" => &["x86_64_linux"],
+        _ => &[],
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn preferred_linux_bottle_tags() -> &'static [&'static str] {
+    preferred_linux_bottle_tags_for_arch(std::env::consts::ARCH)
+}
+
 #[cfg(target_os = "macos")]
 pub fn macos_major_version() -> Option<u32> {
     let output = std::process::Command::new("sw_vers")
@@ -92,11 +106,10 @@ fn select_bottle_with_version(
 
     #[cfg(target_os = "linux")]
     {
-        let linux_tags = ["x86_64_linux"];
-        for preferred_tag in linux_tags {
+        for preferred_tag in preferred_linux_bottle_tags() {
             if let Some(file) = formula.bottle.stable.files.get(preferred_tag) {
                 return Ok(SelectedBottle {
-                    tag: preferred_tag.to_string(),
+                    tag: (*preferred_tag).to_string(),
                     url: file.url.clone(),
                     sha256: file.sha256.clone(),
                 });
@@ -212,6 +225,22 @@ mod tests {
                 "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
             );
         }
+    }
+
+    #[test]
+    fn linux_arm_prefers_arm64_bottle_tags() {
+        assert_eq!(
+            preferred_linux_bottle_tags_for_arch("aarch64"),
+            &["arm64_linux", "aarch64_linux"]
+        );
+    }
+
+    #[test]
+    fn linux_x86_64_prefers_x86_64_bottle_tags() {
+        assert_eq!(
+            preferred_linux_bottle_tags_for_arch("x86_64"),
+            &["x86_64_linux"]
+        );
     }
 
     #[test]

--- a/zb_core/src/formula/resolve.rs
+++ b/zb_core/src/formula/resolve.rs
@@ -193,9 +193,11 @@ mod tests {
     #[test]
     #[cfg(not(target_os = "macos"))]
     fn resolves_uses_from_macos_runtime_dependencies_on_linux() {
+        use crate::formula::UsesFromMacos;
+
         let mut formulas = BTreeMap::new();
         let mut python = formula("python@3.14", &["openssl@3"]);
-        python.uses_from_macos = vec![crate::UsesFromMacos::Plain("expat".to_string())];
+        python.uses_from_macos = vec![UsesFromMacos::Plain("expat".to_string())];
 
         formulas.insert("python@3.14".to_string(), python);
         formulas.insert("openssl@3".to_string(), formula("openssl@3", &[]));

--- a/zb_core/src/formula/resolve.rs
+++ b/zb_core/src/formula/resolve.rs
@@ -21,7 +21,7 @@ pub fn resolve_closure(
     for &idx in &closure {
         let formula = &formulas[idx_to_name[idx]];
         let mut dep_indices: Vec<usize> = formula
-            .dependencies
+            .runtime_dependencies()
             .iter()
             .filter_map(|dep| {
                 let &di = name_to_idx.get(dep.as_str())?;
@@ -91,7 +91,7 @@ fn compute_closure(
         }
 
         let formula = &formulas[idx_to_name[idx]];
-        for dep in &formula.dependencies {
+        for dep in formula.runtime_dependencies() {
             if let Some(&di) = name_to_idx.get(dep.as_str())
                 && !closure.contains(&di)
             {
@@ -188,5 +188,20 @@ mod tests {
         let order = resolve_closure(&["git".to_string()], &formulas).unwrap();
         // Should successfully resolve with just git and gettext
         assert_eq!(order, vec!["gettext", "git"]);
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn resolves_uses_from_macos_runtime_dependencies_on_linux() {
+        let mut formulas = BTreeMap::new();
+        let mut python = formula("python@3.14", &["openssl@3"]);
+        python.uses_from_macos = vec![crate::UsesFromMacos::Plain("expat".to_string())];
+
+        formulas.insert("python@3.14".to_string(), python);
+        formulas.insert("openssl@3".to_string(), formula("openssl@3", &[]));
+        formulas.insert("expat".to_string(), formula("expat", &[]));
+
+        let order = resolve_closure(&["python@3.14".to_string()], &formulas).unwrap();
+        assert_eq!(order, vec!["expat", "openssl@3", "python@3.14"]);
     }
 }

--- a/zb_core/src/formula/types.rs
+++ b/zb_core/src/formula/types.rs
@@ -92,6 +92,20 @@ impl UsesFromMacos {
             UsesFromMacos::WithContext { name, .. } => name,
         }
     }
+
+    pub fn is_runtime_dependency(&self) -> bool {
+        match self {
+            UsesFromMacos::Plain(_) => true,
+            UsesFromMacos::WithContext { context, .. } => context == "runtime",
+        }
+    }
+
+    pub fn is_build_dependency(&self) -> bool {
+        match self {
+            UsesFromMacos::Plain(_) => false,
+            UsesFromMacos::WithContext { context, .. } => context == "build",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
@@ -161,11 +175,66 @@ impl Formula {
         let deps = {
             let mut deps = deps;
             for u in &self.uses_from_macos {
-                deps.push(u.name().to_string());
+                if !deps.iter().any(|dep| dep == u.name()) {
+                    deps.push(u.name().to_string());
+                }
             }
             deps
         };
         deps
+    }
+
+    pub fn runtime_dependencies(&self) -> Vec<String> {
+        let mut deps = self.platform_dependencies();
+
+        #[cfg(not(target_os = "macos"))]
+        for dep in self
+            .uses_from_macos
+            .iter()
+            .filter(|dep| dep.is_runtime_dependency())
+        {
+            if !deps.iter().any(|existing| existing == dep.name()) {
+                deps.push(dep.name().to_string());
+            }
+        }
+
+        deps
+    }
+
+    fn platform_dependencies(&self) -> Vec<String> {
+        #[cfg(target_os = "linux")]
+        if let Some(deps) = self.variation_dependencies(preferred_linux_variation_keys()) {
+            return deps;
+        }
+
+        self.dependencies.clone()
+    }
+
+    fn variation_dependencies(&self, keys: &[&str]) -> Option<Vec<String>> {
+        let variations = self.variations.as_ref()?.as_object()?;
+        for key in keys {
+            if let Some(deps) = variations
+                .get(*key)
+                .and_then(|variation| variation.get("dependencies"))
+                .and_then(|deps| deps.as_array())
+            {
+                return Some(
+                    deps.iter()
+                        .filter_map(|dep| dep.as_str().map(ToString::to_string))
+                        .collect(),
+                );
+            }
+        }
+        None
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn preferred_linux_variation_keys() -> &'static [&'static str] {
+    match std::env::consts::ARCH {
+        "aarch64" => &["arm64_linux", "aarch64_linux"],
+        "x86_64" => &["x86_64_linux"],
+        _ => &[],
     }
 }
 
@@ -410,5 +479,50 @@ mod tests {
         let formula: Formula = serde_json::from_str(json).unwrap();
         assert!(formula.keg_only_reason.is_none());
         assert!(formula.is_keg_only());
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn runtime_dependencies_include_runtime_uses_from_macos_on_linux() {
+        let mut formula: Formula =
+            serde_json::from_str(include_str!("../../fixtures/formula_foo.json")).unwrap();
+        formula.dependencies = vec!["openssl@3".to_string()];
+        formula.uses_from_macos = vec![
+            UsesFromMacos::Plain("expat".to_string()),
+            UsesFromMacos::WithContext {
+                name: "pkgconf".to_string(),
+                context: "build".to_string(),
+            },
+        ];
+
+        assert_eq!(
+            formula.runtime_dependencies(),
+            vec!["openssl@3".to_string(), "expat".to_string()]
+        );
+    }
+
+    #[test]
+    #[cfg(all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    ))]
+    fn runtime_dependencies_use_linux_variation_dependencies() {
+        let mut formula: Formula =
+            serde_json::from_str(include_str!("../../fixtures/formula_foo.json")).unwrap();
+        formula.dependencies = vec!["openssl@3".to_string()];
+        formula.variations = Some(serde_json::json!({
+            "x86_64_linux": { "dependencies": ["openssl@3", "zlib-ng-compat"] },
+            "arm64_linux": { "dependencies": ["openssl@3", "zlib-ng-compat"] }
+        }));
+        formula.uses_from_macos = vec![UsesFromMacos::Plain("expat".to_string())];
+
+        assert_eq!(
+            formula.runtime_dependencies(),
+            vec![
+                "openssl@3".to_string(),
+                "zlib-ng-compat".to_string(),
+                "expat".to_string()
+            ]
+        );
     }
 }

--- a/zb_core/src/formula/types.rs
+++ b/zb_core/src/formula/types.rs
@@ -174,10 +174,8 @@ impl Formula {
         #[cfg(not(target_os = "macos"))]
         let deps = {
             let mut deps = deps;
-            for u in &self.uses_from_macos {
-                if !deps.iter().any(|dep| dep == u.name()) {
-                    deps.push(u.name().to_string());
-                }
+            for u in self.active_uses_from_macos() {
+                push_unique_dep(&mut deps, u.name());
             }
             deps
         };
@@ -188,13 +186,13 @@ impl Formula {
         let mut deps = self.platform_dependencies();
 
         #[cfg(not(target_os = "macos"))]
-        for dep in self
-            .uses_from_macos
-            .iter()
-            .filter(|dep| dep.is_runtime_dependency())
         {
-            if !deps.iter().any(|existing| existing == dep.name()) {
-                deps.push(dep.name().to_string());
+            for dep in self
+                .active_uses_from_macos()
+                .iter()
+                .filter(|dep| dep.is_runtime_dependency())
+            {
+                push_unique_dep(&mut deps, dep.name());
             }
         }
 
@@ -226,6 +224,37 @@ impl Formula {
             }
         }
         None
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn active_uses_from_macos(&self) -> Vec<UsesFromMacos> {
+        #[cfg(target_os = "linux")]
+        if let Some(deps) = self.variation_uses_from_macos(preferred_linux_variation_keys()) {
+            return deps;
+        }
+
+        self.uses_from_macos.clone()
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn variation_uses_from_macos(&self, keys: &[&str]) -> Option<Vec<UsesFromMacos>> {
+        let variations = self.variations.as_ref()?.as_object()?;
+        for key in keys {
+            if let Some(value) = variations
+                .get(*key)
+                .and_then(|variation| variation.get("uses_from_macos"))
+            {
+                return serde_json::from_value(value.clone()).ok();
+            }
+        }
+        None
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn push_unique_dep(deps: &mut Vec<String>, name: &str) {
+    if !deps.iter().any(|existing| existing == name) {
+        deps.push(name.to_string());
     }
 }
 
@@ -522,6 +551,37 @@ mod tests {
                 "openssl@3".to_string(),
                 "zlib-ng-compat".to_string(),
                 "expat".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    #[cfg(all(
+        target_os = "linux",
+        any(target_arch = "x86_64", target_arch = "aarch64")
+    ))]
+    fn runtime_dependencies_include_linux_variation_uses_from_macos() {
+        let mut formula: Formula =
+            serde_json::from_str(include_str!("../../fixtures/formula_foo.json")).unwrap();
+        formula.dependencies = vec!["openssl@3".to_string()];
+        formula.uses_from_macos = vec![UsesFromMacos::Plain("expat".to_string())];
+        formula.variations = Some(serde_json::json!({
+            "x86_64_linux": {
+                "dependencies": ["openssl@3", "zlib-ng-compat"],
+                "uses_from_macos": ["libffi", { "pkgconf": "build" }]
+            },
+            "arm64_linux": {
+                "dependencies": ["openssl@3", "zlib-ng-compat"],
+                "uses_from_macos": ["libffi", { "pkgconf": "build" }]
+            }
+        }));
+
+        assert_eq!(
+            formula.runtime_dependencies(),
+            vec![
+                "openssl@3".to_string(),
+                "zlib-ng-compat".to_string(),
+                "libffi".to_string()
             ]
         );
     }

--- a/zb_io/src/extraction/patch/linux.rs
+++ b/zb_io/src/extraction/patch/linux.rs
@@ -9,6 +9,8 @@ use rayon::prelude::*;
 use tracing::warn;
 use zb_core::Error;
 
+const LINUX_HOMEBREW_PREFIX: &str = "/home/linuxbrew/.linuxbrew";
+
 /// Patch @@HOMEBREW_CELLAR@@ and @@HOMEBREW_PREFIX@@ placeholders in both ELF binaries and text files.
 #[cfg(target_os = "linux")]
 pub fn patch_placeholders(
@@ -20,6 +22,15 @@ pub fn patch_placeholders(
     patch_elf_placeholders(keg_path, prefix_dir)?;
     patch_text_placeholders(keg_path, prefix_dir)?;
     Ok(())
+}
+
+fn rewrite_homebrew_prefixes(input: &str, prefix_dir: &Path) -> String {
+    let prefix_str = prefix_dir.to_string_lossy().into_owned();
+    input
+        .replace("@@HOMEBREW_PREFIX@@", &prefix_str)
+        .replace("@@HOMEBREW_REPOSITORY@@", &prefix_str)
+        .replace("@@HOMEBREW_LIBRARY@@", &format!("{}/Library", prefix_str))
+        .replace(LINUX_HOMEBREW_PREFIX, &prefix_str)
 }
 
 /// Detect if zerobrew has installed its own glibc and return the path to its ld.so interpreter.
@@ -163,7 +174,6 @@ fn patch_elf_placeholders(keg_path: &Path, prefix_dir: &Path) -> Result<(), Erro
 
     // Clone for use in parallel closure
     let target_interpreter = target_interpreter.clone();
-    let old_prefix = "@@HOMEBREW_PREFIX@@";
     let new_prefix = prefix_dir.to_string_lossy().to_string();
 
     elf_files.par_iter().for_each(|path| {
@@ -225,7 +235,7 @@ fn patch_elf_placeholders(keg_path: &Path, prefix_dir: &Path) -> Result<(), Erro
             } else {
                 old_rpaths
                     .iter()
-                    .map(|r| r.replace(old_prefix, &new_prefix))
+                    .map(|r| rewrite_homebrew_prefixes(r, prefix_dir))
                     .filter(|r| r.starts_with(&new_prefix) || r.starts_with("$ORIGIN"))
                     .collect()
             };
@@ -247,8 +257,10 @@ fn patch_elf_placeholders(keg_path: &Path, prefix_dir: &Path) -> Result<(), Erro
             if is_executable && let Some(current_interp_bytes) = elf.inner.elf_interpreter() {
                 let current_interp_str = String::from_utf8_lossy(current_interp_bytes);
 
-                let target_interp_path = if current_interp_str.contains(old_prefix) {
-                    let expanded = current_interp_str.replace(old_prefix, &new_prefix);
+                let target_interp_path = if current_interp_str.contains("@@HOMEBREW_PREFIX@@")
+                    || current_interp_str.contains(LINUX_HOMEBREW_PREFIX)
+                {
+                    let expanded = rewrite_homebrew_prefixes(&current_interp_str, prefix_dir);
                     let expanded_path = PathBuf::from(&expanded);
                     if expanded_path.exists() {
                         Some(expanded_path)
@@ -300,7 +312,6 @@ fn patch_elf_placeholders(keg_path: &Path, prefix_dir: &Path) -> Result<(), Erro
 
 /// Patch text files containing @@HOMEBREW_...@@ placeholders
 fn patch_text_placeholders(keg_path: &Path, prefix_dir: &Path) -> Result<(), Error> {
-    let prefix_str = prefix_dir.to_string_lossy().to_string();
     let cellar_str = prefix_dir.join("Cellar").to_string_lossy().to_string();
 
     // We search for files that are text and contain the placeholders.
@@ -335,15 +346,12 @@ fn patch_text_placeholders(keg_path: &Path, prefix_dir: &Path) -> Result<(), Err
                 Err(_) => return Ok(()), // Not valid UTF-8, skip
             };
 
-            if !content.contains("@@HOMEBREW_") {
+            if !content.contains("@@HOMEBREW_") && !content.contains(LINUX_HOMEBREW_PREFIX) {
                 return Ok(());
             }
 
-            let new_content = content
-                .replace("@@HOMEBREW_PREFIX@@", &prefix_str)
+            let new_content = rewrite_homebrew_prefixes(&content, prefix_dir)
                 .replace("@@HOMEBREW_CELLAR@@", &cellar_str)
-                .replace("@@HOMEBREW_REPOSITORY@@", &prefix_str)
-                .replace("@@HOMEBREW_LIBRARY@@", &format!("{}/Library", prefix_str))
                 .replace("@@HOMEBREW_PERL@@", "/usr/bin/perl")
                 .replace("@@HOMEBREW_JAVA@@", "/usr/bin/java");
 
@@ -415,6 +423,25 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
+    fn rewrites_linuxbrew_prefixes() {
+        let tmp = TempDir::new().unwrap();
+        let prefix = tmp.path().join("prefix");
+
+        assert_eq!(
+            rewrite_homebrew_prefixes(
+                "/home/linuxbrew/.linuxbrew/opt/expat/lib:@@HOMEBREW_PREFIX@@/lib",
+                &prefix
+            ),
+            format!(
+                "{}/opt/expat/lib:{}/lib",
+                prefix.display(),
+                prefix.display()
+            )
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
     fn patches_text_files() {
         let tmp = TempDir::new().unwrap();
         let prefix = tmp.path().join("prefix");
@@ -427,7 +454,7 @@ mod tests {
         let script_path = bin_dir.join("script.sh");
         fs::write(
             &script_path,
-            "#!/bin/bash\necho @@HOMEBREW_PREFIX@@\necho @@HOMEBREW_CELLAR@@\necho @@HOMEBREW_LIBRARY@@\necho @@HOMEBREW_PERL@@",
+            "#!/home/linuxbrew/.linuxbrew/opt/python@3.14/bin/python3.14\necho @@HOMEBREW_PREFIX@@\necho @@HOMEBREW_CELLAR@@\necho @@HOMEBREW_LIBRARY@@\necho @@HOMEBREW_PERL@@",
         )
         .unwrap();
 
@@ -436,6 +463,11 @@ mod tests {
 
         let content = fs::read_to_string(&script_path).unwrap();
         assert!(content.contains(prefix.to_str().unwrap()));
+        assert!(content.starts_with(&format!(
+            "#!{}/opt/python@3.14/bin/python3.14",
+            prefix.display()
+        )));
+        assert!(!content.contains(LINUX_HOMEBREW_PREFIX));
         assert!(content.contains(cellar.to_str().unwrap()));
         assert!(content.contains(&format!("{}/Library", prefix.to_str().unwrap())));
         assert!(content.contains("/usr/bin/perl"));

--- a/zb_io/src/installer/install/plan.rs
+++ b/zb_io/src/installer/install/plan.rs
@@ -101,9 +101,9 @@ impl Installer {
                     continue;
                 }
 
-                for dep in &formula.dependencies {
-                    if !fetched.contains(dep) && !to_fetch.contains(dep) {
-                        to_fetch.push(dep.clone());
+                for dep in formula.runtime_dependencies() {
+                    if !fetched.contains(&dep) && !to_fetch.contains(&dep) {
+                        to_fetch.push(dep);
                     }
                 }
 


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [X] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

Fixes #336.

This addresses Linux Python bottle runtime failures by:

- resolving Linux `uses_from_macos` runtime deps, so `python@3.14` installs deps like `expat`
- honoring Linux variation dependencies
- preferring `arm64_linux` bottles on aarch64
- rewriting literal `/home/linuxbrew/.linuxbrew` paths in Linux bottle text files and ELF RPATH/RUNPATH entries

Together this prevents `pyexpat` from loading stale system libraries and keeps Python wrapper scripts pointing at the zerobrew prefix.