### PR TITLE
fix(zb_io, zb_cli): correct migration behavior on unplannable formulas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-Centralize a single, sandbox-tolerant rustls `ClientConfig` in `network::tls`: prefer native roots, and fall back to the bundled webpki-roots Mozilla roots when no system trust store is available ([#375](https://github.com/lucasgelfond/zerobrew/pull/375))
+- Centralize a single, sandbox-tolerant rustls `ClientConfig` in `network::tls`: prefer native roots, and fall back to the bundled webpki-roots Mozilla roots when no system trust store is available ([#375](https://github.com/lucasgelfond/zerobrew/pull/375))
+- Correct migration behavior on unplannable formulas ([#380](https://github.com/lucasgelfond/zerobrew/pull/380))
 
 ## [0.3.0] - 2026-05-29
 

--- a/zb_cli/src/commands/install.rs
+++ b/zb_cli/src/commands/install.rs
@@ -60,172 +60,7 @@ pub async fn execute(
             }
         };
 
-        ui.heading(format!(
-            "Resolving dependencies ({} packages)...",
-            plan.items.len()
-        ))
-        .map_err(ui_error)?;
-        for item in &plan.items {
-            ui.bullet(format!(
-                "{} {}",
-                style(&item.formula.name).green(),
-                style(&item.formula.versions.stable).dim()
-            ))
-            .map_err(ui_error)?;
-        }
-
-        let multi = MultiProgress::new();
-        let bars: Arc<Mutex<HashMap<String, ProgressBar>>> = Arc::new(Mutex::new(HashMap::new()));
-
-        let download_style = ProgressStyle::default_bar()
-            .template("    {prefix:<16} {bar:25.cyan/dim} {bytes:>10}/{total_bytes:<10} {eta:>6}")
-            .unwrap()
-            .progress_chars("━━╸");
-
-        let spinner_style = ProgressStyle::default_spinner()
-            .template("    {prefix:<16} {spinner:.cyan} {msg}")
-            .unwrap()
-            .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
-
-        let done_style = ProgressStyle::default_spinner()
-            .template("    {prefix:<16} {msg}")
-            .unwrap();
-
-        ui.heading("Downloading and installing formulas...")
-            .map_err(ui_error)?;
-
-        let bars_clone = bars.clone();
-        let multi_clone = multi.clone();
-        let download_style_clone = download_style.clone();
-        let spinner_style_clone = spinner_style.clone();
-        let done_style_clone = done_style.clone();
-
-        let progress_callback: Arc<ProgressCallback> = Arc::new(Box::new(move |event| {
-            let mut bars = bars_clone.lock().unwrap();
-            match event {
-                InstallProgress::DownloadStarted { name, total_bytes } => {
-                    let pb = if let Some(total) = total_bytes {
-                        let pb = multi_clone.add(ProgressBar::new(total));
-                        pb.set_style(download_style_clone.clone());
-                        pb
-                    } else {
-                        let pb = multi_clone.add(ProgressBar::new_spinner());
-                        pb.set_style(spinner_style_clone.clone());
-                        pb.set_message("downloading...");
-                        pb.enable_steady_tick(std::time::Duration::from_millis(80));
-                        pb
-                    };
-                    pb.set_prefix(name.clone());
-                    bars.insert(name, pb);
-                }
-                InstallProgress::DownloadProgress {
-                    name,
-                    downloaded,
-                    total_bytes,
-                } => {
-                    if let Some(pb) = bars.get(&name)
-                        && total_bytes.is_some()
-                    {
-                        pb.set_position(downloaded);
-                    }
-                }
-                InstallProgress::DownloadCompleted { name, total_bytes } => {
-                    if let Some(pb) = bars.get(&name) {
-                        if total_bytes > 0 {
-                            pb.set_position(total_bytes);
-                        }
-                        pb.set_style(spinner_style_clone.clone());
-                        pb.set_message("unpacking...");
-                        pb.enable_steady_tick(std::time::Duration::from_millis(80));
-                    }
-                }
-                InstallProgress::UnpackStarted { name } => {
-                    if let Some(pb) = bars.get(&name) {
-                        pb.set_message("unpacking...");
-                    }
-                }
-                InstallProgress::UnpackCompleted { name } => {
-                    if let Some(pb) = bars.get(&name) {
-                        pb.set_message("unpacked");
-                    }
-                }
-                InstallProgress::LinkStarted { name } => {
-                    if let Some(pb) = bars.get(&name) {
-                        pb.set_message("linking...");
-                    }
-                }
-                InstallProgress::LinkCompleted { name } => {
-                    if let Some(pb) = bars.get(&name) {
-                        pb.set_message("linked");
-                    }
-                }
-                InstallProgress::LinkSkipped { name, reason } => {
-                    if let Some(pb) = bars.get(&name) {
-                        pb.set_message(format!("keg-only ({})", reason));
-                    }
-                }
-                InstallProgress::InstallCompleted { name } => {
-                    if let Some(pb) = bars.get(&name) {
-                        pb.set_style(done_style_clone.clone());
-                        pb.set_message(format!("{} installed", style("✓").green()));
-                        pb.finish();
-                    }
-                }
-            }
-        }));
-
-        let result_val = installer
-            .execute_with_progress(plan, !no_link, Some(progress_callback))
-            .await;
-
-        {
-            let bars = bars.lock().unwrap();
-            for (_, pb) in bars.iter() {
-                if !pb.is_finished() {
-                    pb.finish();
-                }
-            }
-        }
-
-        let result = match result_val {
-            Ok(r) => r,
-            Err(ref e @ zb_core::Error::LinkConflict { ref conflicts }) => {
-                ui.blank_line().map_err(ui_error)?;
-                ui.error("The link step did not complete successfully.")
-                    .map_err(ui_error)?;
-                ui.println("The formula was installed, but is not symlinked into the prefix.")
-                    .map_err(ui_error)?;
-                ui.blank_line().map_err(ui_error)?;
-                ui.println("Possible conflicting files:")
-                    .map_err(ui_error)?;
-                for c in conflicts {
-                    if let Some(ref owner) = c.owned_by {
-                        ui.println(format!(
-                            "  {} (symlink belonging to {})",
-                            c.path.display(),
-                            style(owner).yellow()
-                        ))
-                        .map_err(ui_error)?;
-                    } else {
-                        ui.println(format!("  {}", c.path.display()))
-                            .map_err(ui_error)?;
-                    }
-                }
-                ui.blank_line().map_err(ui_error)?;
-                return Err(e.clone());
-            }
-            Err(e) => {
-                let handled_missing = suggest_missing_formula_matches(installer, &e).await;
-
-                if !handled_missing {
-                    for formula in &formulas {
-                        suggest_homebrew(formula, &e);
-                    }
-                }
-                return Err(e);
-            }
-        };
-        installed_count += result.installed;
+        installed_count += execute_formula_plan(installer, &formulas, plan, no_link, ui).await?;
     }
 
     if !cask_names.is_empty() {
@@ -248,6 +83,180 @@ pub async fn execute(
     .map_err(ui_error)?;
 
     Ok(())
+}
+
+pub async fn execute_formula_plan(
+    installer: &mut zb_io::Installer,
+    requested_formulas: &[String],
+    plan: zb_io::InstallPlan,
+    no_link: bool,
+    ui: &mut StdUi,
+) -> Result<usize, zb_core::Error> {
+    ui.heading(format!(
+        "Resolving dependencies ({} packages)...",
+        plan.items.len()
+    ))
+    .map_err(ui_error)?;
+    for item in &plan.items {
+        ui.bullet(format!(
+            "{} {}",
+            style(&item.formula.name).green(),
+            style(&item.formula.versions.stable).dim()
+        ))
+        .map_err(ui_error)?;
+    }
+
+    let multi = MultiProgress::new();
+    let bars: Arc<Mutex<HashMap<String, ProgressBar>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    let download_style = ProgressStyle::default_bar()
+        .template("    {prefix:<16} {bar:25.cyan/dim} {bytes:>10}/{total_bytes:<10} {eta:>6}")
+        .unwrap()
+        .progress_chars("━━╸");
+
+    let spinner_style = ProgressStyle::default_spinner()
+        .template("    {prefix:<16} {spinner:.cyan} {msg}")
+        .unwrap()
+        .tick_chars("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏");
+
+    let done_style = ProgressStyle::default_spinner()
+        .template("    {prefix:<16} {msg}")
+        .unwrap();
+
+    ui.heading("Downloading and installing formulas...")
+        .map_err(ui_error)?;
+
+    let bars_clone = bars.clone();
+    let multi_clone = multi.clone();
+    let download_style_clone = download_style.clone();
+    let spinner_style_clone = spinner_style.clone();
+    let done_style_clone = done_style.clone();
+
+    let progress_callback: Arc<ProgressCallback> = Arc::new(Box::new(move |event| {
+        let mut bars = bars_clone.lock().unwrap();
+        match event {
+            InstallProgress::DownloadStarted { name, total_bytes } => {
+                let pb = if let Some(total) = total_bytes {
+                    let pb = multi_clone.add(ProgressBar::new(total));
+                    pb.set_style(download_style_clone.clone());
+                    pb
+                } else {
+                    let pb = multi_clone.add(ProgressBar::new_spinner());
+                    pb.set_style(spinner_style_clone.clone());
+                    pb.set_message("downloading...");
+                    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+                    pb
+                };
+                pb.set_prefix(name.clone());
+                bars.insert(name, pb);
+            }
+            InstallProgress::DownloadProgress {
+                name,
+                downloaded,
+                total_bytes,
+            } => {
+                if let Some(pb) = bars.get(&name)
+                    && total_bytes.is_some()
+                {
+                    pb.set_position(downloaded);
+                }
+            }
+            InstallProgress::DownloadCompleted { name, total_bytes } => {
+                if let Some(pb) = bars.get(&name) {
+                    if total_bytes > 0 {
+                        pb.set_position(total_bytes);
+                    }
+                    pb.set_style(spinner_style_clone.clone());
+                    pb.set_message("unpacking...");
+                    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+                }
+            }
+            InstallProgress::UnpackStarted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message("unpacking...");
+                }
+            }
+            InstallProgress::UnpackCompleted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message("unpacked");
+                }
+            }
+            InstallProgress::LinkStarted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message("linking...");
+                }
+            }
+            InstallProgress::LinkCompleted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message("linked");
+                }
+            }
+            InstallProgress::LinkSkipped { name, reason } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_message(format!("keg-only ({})", reason));
+                }
+            }
+            InstallProgress::InstallCompleted { name } => {
+                if let Some(pb) = bars.get(&name) {
+                    pb.set_style(done_style_clone.clone());
+                    pb.set_message(format!("{} installed", style("✓").green()));
+                    pb.finish();
+                }
+            }
+        }
+    }));
+
+    let result_val = installer
+        .execute_with_progress(plan, !no_link, Some(progress_callback))
+        .await;
+
+    {
+        let bars = bars.lock().unwrap();
+        for (_, pb) in bars.iter() {
+            if !pb.is_finished() {
+                pb.finish();
+            }
+        }
+    }
+
+    match result_val {
+        Ok(result) => Ok(result.installed),
+        Err(ref e @ zb_core::Error::LinkConflict { ref conflicts }) => {
+            ui.blank_line().map_err(ui_error)?;
+            ui.error("The link step did not complete successfully.")
+                .map_err(ui_error)?;
+            ui.println("The formula was installed, but is not symlinked into the prefix.")
+                .map_err(ui_error)?;
+            ui.blank_line().map_err(ui_error)?;
+            ui.println("Possible conflicting files:")
+                .map_err(ui_error)?;
+            for c in conflicts {
+                if let Some(ref owner) = c.owned_by {
+                    ui.println(format!(
+                        "  {} (symlink belonging to {})",
+                        c.path.display(),
+                        style(owner).yellow()
+                    ))
+                    .map_err(ui_error)?;
+                } else {
+                    ui.println(format!("  {}", c.path.display()))
+                        .map_err(ui_error)?;
+                }
+            }
+            ui.blank_line().map_err(ui_error)?;
+            Err(e.clone())
+        }
+        Err(e) => {
+            let handled_missing = suggest_missing_formula_matches(installer, &e).await;
+
+            if !handled_missing {
+                for formula in requested_formulas {
+                    suggest_homebrew(formula, &e);
+                }
+            }
+            Err(e)
+        }
+    }
 }
 
 fn ui_error(err: std::io::Error) -> zb_core::Error {

--- a/zb_cli/src/commands/migrate.rs
+++ b/zb_cli/src/commands/migrate.rs
@@ -84,15 +84,31 @@ pub async fn execute(
 
     let formula_names: Vec<String> = packages.formulas.iter().map(|f| f.name.clone()).collect();
 
-    crate::commands::install::execute(
-        installer,
-        formula_names.clone(),
-        false, // no_link
-        false, // build_from_source
-        ui,
-    )
-    .await
-    .ok();
+    let (plan, planning_failures) = installer.plan_best_effort(&formula_names, false).await;
+    if !planning_failures.is_empty() {
+        ui.note(format!(
+            "Skipped {} formula(s) that could not be planned:",
+            planning_failures.len()
+        ))
+        .map_err(ui_error)?;
+        for failure in &planning_failures {
+            ui.bullet(format!("{} ({})", failure.name, failure.error))
+                .map_err(ui_error)?;
+        }
+        ui.blank_line().map_err(ui_error)?;
+    }
+
+    if !plan.items.is_empty() {
+        crate::commands::install::execute_formula_plan(
+            installer,
+            &formula_names,
+            plan,
+            false, // no_link
+            ui,
+        )
+        .await
+        .ok();
+    }
 
     let (successfully_installed, failed_installed) =
         check_install_status(installer, &formula_names)?;

--- a/zb_io/src/installer/install/mod.rs
+++ b/zb_io/src/installer/install/mod.rs
@@ -66,6 +66,12 @@ pub struct InstallPlan {
     pub items: Vec<PlannedInstall>,
 }
 
+#[derive(Debug)]
+pub struct PlanFailure {
+    pub name: String,
+    pub error: Error,
+}
+
 pub struct ExecuteResult {
     pub installed: usize,
 }

--- a/zb_io/src/installer/install/plan.rs
+++ b/zb_io/src/installer/install/plan.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use tracing::warn;
 use zb_core::{BuildPlan, Error, Formula, InstallMethod, select_bottle};
@@ -21,36 +21,7 @@ impl Installer {
         let mut items = Vec::with_capacity(ordered.len());
         for install_name in ordered {
             let formula = formulas.get(&install_name).cloned().unwrap();
-            let method = if build_from_source {
-                match BuildPlan::from_formula(&formula, &self.prefix) {
-                    Some(plan) => InstallMethod::Source(plan),
-                    None => match select_bottle(&formula) {
-                        Ok(bottle) => InstallMethod::Bottle(bottle),
-                        Err(_) => {
-                            return Err(Error::UnsupportedBottle {
-                                name: formula.name.clone(),
-                            });
-                        }
-                    },
-                }
-            } else {
-                match select_bottle(&formula) {
-                    Ok(bottle) => InstallMethod::Bottle(bottle),
-                    Err(_) => match BuildPlan::from_formula(&formula, &self.prefix) {
-                        Some(plan) => InstallMethod::Source(plan),
-                        None => {
-                            return Err(Error::UnsupportedBottle {
-                                name: formula.name.clone(),
-                            });
-                        }
-                    },
-                }
-            };
-            items.push(PlannedInstall {
-                install_name,
-                formula,
-                method,
-            });
+            items.push(self.plan_item(install_name, formula, build_from_source)?);
         }
 
         Ok(InstallPlan { items })
@@ -61,30 +32,174 @@ impl Installer {
         names: &[String],
         build_from_source: bool,
     ) -> (InstallPlan, Vec<PlanFailure>) {
+        let (formulas, fetch_failures) = self.fetch_all_formulas_best_effort(names).await;
         let mut items = Vec::new();
-        let mut seen = HashSet::new();
         let mut failures = Vec::new();
+        let mut valid_roots = Vec::new();
+        let mut seen_roots = HashSet::new();
 
         for name in names {
-            match self
-                .plan_with_options(std::slice::from_ref(name), build_from_source)
-                .await
-            {
-                Ok(plan) => {
-                    for item in plan.items {
-                        if seen.insert(item.install_name.clone()) {
-                            items.push(item);
+            if !seen_roots.insert(name.clone()) {
+                continue;
+            }
+
+            if let Some(error) = fetch_failures.get(name) {
+                failures.push(PlanFailure {
+                    name: name.clone(),
+                    error: error.clone(),
+                });
+                continue;
+            }
+
+            if !formulas.contains_key(name) {
+                failures.push(PlanFailure {
+                    name: name.clone(),
+                    error: Error::MissingFormula { name: name.clone() },
+                });
+                continue;
+            }
+
+            if let Some(failure) = root_dependency_failure(name, &formulas, &fetch_failures) {
+                failures.push(failure);
+                continue;
+            }
+
+            valid_roots.push(name.clone());
+        }
+
+        if !valid_roots.is_empty() {
+            match zb_core::resolve_closure(&valid_roots, &formulas) {
+                Ok(ordered) => {
+                    for install_name in ordered {
+                        let formula = formulas.get(&install_name).cloned().unwrap();
+                        match self.plan_item(install_name.clone(), formula, build_from_source) {
+                            Ok(item) => items.push(item),
+                            Err(error) => failures.push(PlanFailure {
+                                name: install_name,
+                                error,
+                            }),
                         }
                     }
                 }
-                Err(error) => failures.push(PlanFailure {
-                    name: name.clone(),
-                    error,
-                }),
+                Err(error) => {
+                    failures.extend(valid_roots.into_iter().map(|name| PlanFailure {
+                        name,
+                        error: error.clone(),
+                    }));
+                }
             }
         }
 
         (InstallPlan { items }, failures)
+    }
+
+    fn plan_item(
+        &self,
+        install_name: String,
+        formula: Formula,
+        build_from_source: bool,
+    ) -> Result<PlannedInstall, Error> {
+        let method = if build_from_source {
+            match BuildPlan::from_formula(&formula, &self.prefix) {
+                Some(plan) => InstallMethod::Source(plan),
+                None => match select_bottle(&formula) {
+                    Ok(bottle) => InstallMethod::Bottle(bottle),
+                    Err(_) => {
+                        return Err(Error::UnsupportedBottle {
+                            name: formula.name.clone(),
+                        });
+                    }
+                },
+            }
+        } else {
+            match select_bottle(&formula) {
+                Ok(bottle) => InstallMethod::Bottle(bottle),
+                Err(_) => match BuildPlan::from_formula(&formula, &self.prefix) {
+                    Some(plan) => InstallMethod::Source(plan),
+                    None => {
+                        return Err(Error::UnsupportedBottle {
+                            name: formula.name.clone(),
+                        });
+                    }
+                },
+            }
+        };
+
+        Ok(PlannedInstall {
+            install_name,
+            formula,
+            method,
+        })
+    }
+
+    async fn fetch_all_formulas_best_effort(
+        &self,
+        names: &[String],
+    ) -> (BTreeMap<String, Formula>, HashMap<String, Error>) {
+        let mut formulas = BTreeMap::new();
+        let mut failures = HashMap::new();
+        let mut fetched: HashSet<String> = HashSet::new();
+        let mut to_fetch: Vec<String> = names.to_vec();
+
+        while !to_fetch.is_empty() {
+            let batch: Vec<String> = to_fetch
+                .drain(..)
+                .filter(|n| !fetched.contains(n))
+                .collect();
+
+            if batch.is_empty() {
+                break;
+            }
+
+            for n in &batch {
+                fetched.insert(n.clone());
+            }
+
+            let futures: Vec<_> = batch
+                .iter()
+                .map(|n| self.api_client.get_formula(n))
+                .collect();
+
+            let results = futures::future::join_all(futures).await;
+
+            for (i, result) in results.into_iter().enumerate() {
+                let fetch_name = batch[i].clone();
+                let formula = match result {
+                    Ok(f) => f,
+                    Err(error) => {
+                        failures.insert(fetch_name, error);
+                        continue;
+                    }
+                };
+
+                if select_bottle(&formula).is_err() && !formula.has_source_url() {
+                    warn!(
+                        formula = %formula.name,
+                        "skipping formula with no bottle or source available for this platform"
+                    );
+                    failures.insert(
+                        fetch_name,
+                        Error::UnsupportedBottle {
+                            name: formula.name.clone(),
+                        },
+                    );
+                    continue;
+                }
+
+                for dep in formula.runtime_dependencies() {
+                    if !fetched.contains(&dep)
+                        && !to_fetch.contains(&dep)
+                        && !failures.contains_key(&dep)
+                    {
+                        to_fetch.push(dep);
+                    }
+                }
+
+                formulas.insert(fetch_name, formula);
+            }
+        }
+
+        (formulas, failures)
     }
 
     async fn fetch_all_formulas(
@@ -144,6 +259,42 @@ impl Installer {
 
         Ok(formulas)
     }
+}
+
+fn root_dependency_failure(
+    root: &str,
+    formulas: &BTreeMap<String, Formula>,
+    fetch_failures: &HashMap<String, Error>,
+) -> Option<PlanFailure> {
+    let mut seen = HashSet::new();
+    let mut stack = vec![root.to_string()];
+
+    while let Some(name) = stack.pop() {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+
+        let Some(formula) = formulas.get(&name) else {
+            continue;
+        };
+
+        for dep in formula.runtime_dependencies() {
+            if let Some(error) = fetch_failures.get(&dep) {
+                return Some(PlanFailure {
+                    name: root.to_string(),
+                    error: Error::ExecutionError {
+                        message: format!("dependency '{dep}' could not be planned: {error}"),
+                    },
+                });
+            }
+
+            if formulas.contains_key(&dep) {
+                stack.push(dep);
+            }
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/zb_io/src/installer/install/plan.rs
+++ b/zb_io/src/installer/install/plan.rs
@@ -1,9 +1,9 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use tracing::warn;
 use zb_core::{BuildPlan, Error, Formula, InstallMethod, select_bottle};
 
-use super::{InstallPlan, Installer, PlannedInstall};
+use super::{InstallPlan, Installer, PlanFailure, PlannedInstall};
 
 impl Installer {
     pub async fn plan(&self, names: &[String]) -> Result<InstallPlan, Error> {
@@ -54,6 +54,37 @@ impl Installer {
         }
 
         Ok(InstallPlan { items })
+    }
+
+    pub async fn plan_best_effort(
+        &self,
+        names: &[String],
+        build_from_source: bool,
+    ) -> (InstallPlan, Vec<PlanFailure>) {
+        let mut items = Vec::new();
+        let mut seen = HashSet::new();
+        let mut failures = Vec::new();
+
+        for name in names {
+            match self
+                .plan_with_options(std::slice::from_ref(name), build_from_source)
+                .await
+            {
+                Ok(plan) => {
+                    for item in plan.items {
+                        if seen.insert(item.install_name.clone()) {
+                            items.push(item);
+                        }
+                    }
+                }
+                Err(error) => failures.push(PlanFailure {
+                    name: name.clone(),
+                    error,
+                }),
+            }
+        }
+
+        (InstallPlan { items }, failures)
     }
 
     async fn fetch_all_formulas(
@@ -405,6 +436,85 @@ end
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
+            zb_core::Error::MissingFormula { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn plan_best_effort_keeps_valid_formula_when_another_is_missing() {
+        let mock_server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+
+        let tag = get_test_bottle_tag();
+        let formula_json = format!(
+            r#"{{
+                "name": "goodpkg",
+                "versions": {{ "stable": "1.0.0" }},
+                "dependencies": [],
+                "bottle": {{
+                    "stable": {{
+                        "files": {{
+                            "{}": {{
+                                "url": "{}/bottles/goodpkg-1.0.0.{}.bottle.tar.gz",
+                                "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                            }}
+                        }}
+                    }}
+                }}
+            }}"#,
+            tag,
+            mock_server.uri(),
+            tag
+        );
+
+        Mock::given(method("GET"))
+            .and(path("/formula/goodpkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/formula/missingpkg.json"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/formula.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("[]"))
+            .mount(&mock_server)
+            .await;
+
+        let root = tmp.path().join("zerobrew");
+        let prefix = tmp.path().join("homebrew");
+        fs::create_dir_all(root.join("db")).unwrap();
+
+        let api_client =
+            ApiClient::with_base_url(format!("{}/formula", mock_server.uri())).unwrap();
+        let blob_cache = BlobCache::new(&root.join("cache")).unwrap();
+        let store = Store::new(&root).unwrap();
+        let cellar = Cellar::new(&root).unwrap();
+        let linker = Linker::new(&prefix).unwrap();
+        let db = Database::open(&root.join("db/zb.sqlite3")).unwrap();
+
+        let installer = Installer::new(
+            api_client,
+            blob_cache,
+            store,
+            cellar,
+            linker,
+            db,
+            prefix.clone(),
+            root.join("locks"),
+        );
+
+        let names = vec!["goodpkg".to_string(), "missingpkg".to_string()];
+        let (plan, failures) = installer.plan_best_effort(&names, false).await;
+
+        assert_eq!(plan.items.len(), 1);
+        assert_eq!(plan.items[0].install_name, "goodpkg");
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].name, "missingpkg");
+        assert!(matches!(
+            failures[0].error,
             zb_core::Error::MissingFormula { .. }
         ));
     }

--- a/zb_io/src/installer/mod.rs
+++ b/zb_io/src/installer/mod.rs
@@ -7,4 +7,6 @@ pub use homebrew::{
     parse_casks_from_plain_text, parse_formulas_from_json,
 };
 pub use install::doctor::{DiagnosticReport, RepairSummary};
-pub use install::{ExecuteResult, InstallPlan, Installer, OutdatedPackage, create_installer};
+pub use install::{
+    ExecuteResult, InstallPlan, Installer, OutdatedPackage, PlanFailure, create_installer,
+};

--- a/zb_io/src/lib.rs
+++ b/zb_io/src/lib.rs
@@ -14,7 +14,8 @@ pub use cellar::{Cellar, LinkedFile, Linker, MaterializedKeg};
 pub use extraction::extract_tarball;
 pub use installer::{
     DiagnosticReport, ExecuteResult, HomebrewMigrationPackages, HomebrewPackage, InstallPlan,
-    Installer, OutdatedPackage, RepairSummary, create_installer, get_homebrew_packages,
+    Installer, OutdatedPackage, PlanFailure, RepairSummary, create_installer,
+    get_homebrew_packages,
 };
 pub use network::{
     ApiCache, ApiClient, DownloadProgressCallback, DownloadRequest, Downloader, ParallelDownloader,


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [X] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

Fixes #338 

- Added `Installer::plan_best_effort(...)` so migration can skip formulas that fail planning instead of aborting the whole batch.
- `zb migrate` now reports skipped planning failures, then installs the valid combined plan.
- Extracted the CLI install progress path into `execute_formula_plan(...)` so migrate can reuse it.
- Added a focused test for “one valid formula, one missing formula”.

#379 should be follow up from this


