### PR TITLE
clarify installer shell setup output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Centralize a single, sandbox-tolerant rustls `ClientConfig` in `network::tls`: prefer native roots, and fall back to the bundled webpki-roots Mozilla roots when no system trust store is available ([#375](https://github.com/lucasgelfond/zerobrew/pull/375))
 - Correct migration behavior on unplannable formulas ([#380](https://github.com/lucasgelfond/zerobrew/pull/380))
 
+### Changed
+- Clarify standalone installer shell setup and update flow: surface `zb init` output, print the `source` command after shell config changes, print exact `export`/fish commands for `--no-modify-path`, report installed/updated/already-current status on reruns, and warn when an older `zb` still appears earlier in `PATH` ([#381](https://github.com/lucasgelfond/zerobrew/pull/381))
+- Clarify `zb update` help/output and README update docs so users know `zb update` refreshes package metadata while the installer or Homebrew updates the `zb` binary itself ([#381](https://github.com/lucasgelfond/zerobrew/pull/381))
+
 ## [0.3.0] - 2026-05-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
 curl -fsSL https://zerobrew.rs/install | bash
 ```
 
-After install, run the `export` command it prints (or restart your terminal).
+The installer updates your shell config. After it finishes, restart your terminal
+or run the `source` command it prints.
 
 Or via Homebrew:
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ Or via Homebrew:
 brew install lucasgelfond/zerobrew/zerobrew
 ```
 
+## Update zerobrew
+
+If you used the standalone installer, rerun it:
+
+```bash
+curl -fsSL https://zerobrew.rs/install | bash
+zb --version
+```
+
+If you installed with Homebrew:
+
+```bash
+brew update && brew upgrade zerobrew
+```
+
 ## Quick start
 
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -26,7 +26,7 @@
 curl -fsSL https://zerobrew.rs/install | bash
 ```
 
-安装完成后，运行它打印的 `export` 命令（或重启终端）。
+安装程序会更新你的 shell 配置。完成后，重启终端，或运行它打印的 `source` 命令。
 
 或通过 Homebrew 安装：
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,6 +34,23 @@ curl -fsSL https://zerobrew.rs/install | bash
 brew install lucasgelfond/zerobrew/zerobrew
 ```
 
+## 更新 zerobrew (Update zerobrew)
+
+如果使用独立安装脚本，重新运行：
+
+```bash
+curl -fsSL https://zerobrew.rs/install | bash
+zb --version
+```
+
+如果通过 Homebrew 安装：
+
+```bash
+brew update && brew upgrade zerobrew
+```
+
+`zb update` 只刷新软件包元数据。`zb upgrade` 升级通过 zerobrew 安装的软件包。它们都不会更新 `zb` 二进制文件本身。
+
 ## 快速开始 (Quick start)
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -195,7 +195,7 @@ zb_init() {
         init_args+=("--no-modify-path")
     fi
 
-    "$zb_path" init ${init_args[@]+"${init_args[@]}"} >/dev/null 2>&1 || error_exit "Failed to initialize zerobrew"
+    "$zb_path" init ${init_args[@]+"${init_args[@]}"} || error_exit "Failed to initialize zerobrew"
 }
 
 finalize_installation() {

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,8 @@ trap cleanup EXIT
 ZEROBREW_REPO="https://github.com/lucasgelfond/zerobrew.git"
 : "${ZEROBREW_DIR:=$HOME/.zerobrew}"
 : "${ZEROBREW_BIN:=$HOME/.local/bin}"
+ORIGINAL_PATH="$PATH"
+PREVIOUS_ZB_VERSION=""
 
 if [[ -d "/opt/zerobrew" ]]; then
     ZEROBREW_ROOT="/opt/zerobrew"
@@ -148,6 +150,46 @@ warn() {
     printf "%b[!]%b %b\n" "$ORANGE" "$NC" "$1" >&2
 }
 
+zb_version() {
+    local zb_path="$1"
+
+    if [[ -x "$zb_path" ]]; then
+        "$zb_path" --version 2>/dev/null || true
+    fi
+}
+
+detect_existing_zb() {
+    PREVIOUS_ZB_VERSION="$(zb_version "$ZEROBREW_BIN/zb")"
+}
+
+report_zb_version() {
+    local installed_zb="$ZEROBREW_BIN/zb"
+    local installed_version
+    installed_version="$(zb_version "$installed_zb")"
+
+    if [[ -z "$installed_version" ]]; then
+        return
+    fi
+
+    if [[ -z "$PREVIOUS_ZB_VERSION" ]]; then
+        completed "Installed ${ORANGE}${installed_version}${NC}"
+    elif [[ "$PREVIOUS_ZB_VERSION" == "$installed_version" ]]; then
+        completed "${ORANGE}${installed_version}${NC} is already up to date"
+    else
+        completed "Updated zerobrew from ${ORANGE}${PREVIOUS_ZB_VERSION}${NC} to ${ORANGE}${installed_version}${NC}"
+    fi
+
+    local current_path_zb
+    current_path_zb="$(PATH="$ORIGINAL_PATH" command -v zb 2>/dev/null || true)"
+    if [[ -z "$current_path_zb" ]]; then
+        warn "zb is installed at ${installed_zb}, but your current shell may not see it until you restart or source your shell config."
+    elif [[ "$current_path_zb" != "$installed_zb" ]]; then
+        local current_path_version
+        current_path_version="$(zb_version "$current_path_zb")"
+        warn "Your current shell finds ${current_path_zb}${current_path_version:+ ($current_path_version)} before ${installed_zb}. Restart your terminal or adjust PATH if zb still reports an old version."
+    fi
+}
+
 check_command() {
     local cmd="$1"
     local install_hint="${2:-}"
@@ -212,6 +254,7 @@ finalize_installation() {
     fi
 
     zb_init "$ZEROBREW_BIN/zb" "$no_modify"
+    report_zb_version
 
     print_logo
     completed "Installation complete"
@@ -352,6 +395,8 @@ while [[ $# -gt 0 ]]; do
         ;;
     esac
 done
+
+detect_existing_zb
 
 # Skip all if binary path is provided
 if [[ ${#binary_paths[@]} -gt 0 ]]; then

--- a/zb_cli/src/cli.rs
+++ b/zb_cli/src/cli.rs
@@ -177,7 +177,7 @@ pub enum Commands {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
-    /// Clear cached formula data
+    /// Refresh cached formula metadata
     Update,
     /// List installed packages with newer versions available
     Outdated {

--- a/zb_cli/src/commands/update.rs
+++ b/zb_cli/src/commands/update.rs
@@ -12,6 +12,13 @@ pub fn execute(installer: &mut zb_io::Installer) -> Result<(), zb_core::Error> {
             if removed == 1 { "entry" } else { "entries" }
         );
     }
-    println!("{}", style("Run `zb outdated` to check for updates.").dim());
+    println!(
+        "{}",
+        style("Run `zb outdated` to check package updates.").dim()
+    );
+    println!(
+        "{}",
+        style("This does not update the zb binary; use the installer or Homebrew for that.").dim()
+    );
     Ok(())
 }

--- a/zb_cli/src/init.rs
+++ b/zb_cli/src/init.rs
@@ -415,14 +415,40 @@ end
                 zerobrew_bin,
                 prefix_bin.display()
             ))?;
+            ui.info(format!(
+                "Restart your terminal or run: source {}",
+                config_file
+            ))?;
         }
     } else if no_modify_path {
         ui.info("Skipped shell configuration (--no-modify-path)")?;
-        ui.info(format!(
-            "To use zerobrew, add {} and {} to your PATH",
-            zerobrew_bin,
-            prefix_bin.display()
-        ))?;
+        match shell_kind {
+            ShellConfigKind::Posix => {
+                ui.info("Run this in your current shell:")?;
+                ui.println(format!("    export ZEROBREW_DIR={zerobrew_dir}"))?;
+                ui.println(format!("    export ZEROBREW_ROOT={}", root.display()))?;
+                ui.println(format!("    export ZEROBREW_PREFIX={}", prefix.display()))?;
+                ui.println(format!(
+                    "    export PATH=\"{}:{}:$PATH\"",
+                    zerobrew_bin,
+                    prefix_bin.display()
+                ))?;
+            }
+            ShellConfigKind::Fish => {
+                ui.info("Run this in your current shell:")?;
+                ui.println(format!("    set -gx ZEROBREW_DIR \"{zerobrew_dir}\""))?;
+                ui.println(format!("    set -gx ZEROBREW_ROOT \"{}\"", root.display()))?;
+                ui.println(format!(
+                    "    set -gx ZEROBREW_PREFIX \"{}\"",
+                    prefix.display()
+                ))?;
+                ui.println(format!(
+                    "    set -gx PATH \"{}\" \"{}\" $PATH",
+                    zerobrew_bin,
+                    prefix_bin.display()
+                ))?;
+            }
+        }
     }
 
     Ok(())

--- a/zb_cli/src/init.rs
+++ b/zb_cli/src/init.rs
@@ -225,6 +225,24 @@ fn upsert_managed_block(existing: &str, managed_block: &str) -> String {
     }
 }
 
+fn posix_shell_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_string();
+    }
+
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn fish_shell_quote(value: &str) -> String {
+    format!(
+        "\"{}\"",
+        value
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('$', "\\$")
+    )
+}
+
 fn add_to_path(
     prefix: &Path,
     zerobrew_dir: &str,
@@ -233,6 +251,7 @@ fn add_to_path(
     no_modify_path: bool,
     ui: &mut StdUi,
 ) -> Result<(), InitError> {
+    #[derive(Clone, Copy)]
     enum ShellConfigKind {
         Posix,
         Fish,
@@ -271,6 +290,9 @@ fn add_to_path(
     };
 
     let prefix_bin = prefix.join("bin");
+    let root_str = root.display().to_string();
+    let prefix_str = prefix.display().to_string();
+    let prefix_bin_str = prefix_bin.display().to_string();
     let existing_config = std::fs::read_to_string(&config_file).unwrap_or_default();
 
     if !no_modify_path {
@@ -323,18 +345,18 @@ _zb_path_append() {{
 _zb_path_append "$ZEROBREW_BIN"
 _zb_path_append "$ZEROBREW_PREFIX/bin"
 "#,
-                zerobrew_dir = zerobrew_dir,
-                zerobrew_bin = zerobrew_bin,
-                root = root.display(),
-                prefix = prefix.display()
+                zerobrew_dir = posix_shell_quote(zerobrew_dir),
+                zerobrew_bin = posix_shell_quote(zerobrew_bin),
+                root = posix_shell_quote(&root_str),
+                prefix = posix_shell_quote(&prefix_str)
             ),
             ShellConfigKind::Fish => format!(
                 r#"
 # zerobrew
-set -gx ZEROBREW_DIR "{zerobrew_dir}"
-set -gx ZEROBREW_BIN "{zerobrew_bin}"
-set -gx ZEROBREW_ROOT "{root}"
-set -gx ZEROBREW_PREFIX "{prefix}"
+set -gx ZEROBREW_DIR {zerobrew_dir}
+set -gx ZEROBREW_BIN {zerobrew_bin}
+set -gx ZEROBREW_ROOT {root}
+set -gx ZEROBREW_PREFIX {prefix}
 if set -q PKG_CONFIG_PATH
     set -gx PKG_CONFIG_PATH "$ZEROBREW_PREFIX/lib/pkgconfig" $PKG_CONFIG_PATH
 else
@@ -375,10 +397,10 @@ if not contains -- "$ZEROBREW_PREFIX/bin" $PATH
     set -gx PATH "$ZEROBREW_PREFIX/bin" $PATH
 end
 "#,
-                zerobrew_dir = zerobrew_dir,
-                zerobrew_bin = zerobrew_bin,
-                root = root.display(),
-                prefix = prefix.display()
+                zerobrew_dir = fish_shell_quote(zerobrew_dir),
+                zerobrew_bin = fish_shell_quote(zerobrew_bin),
+                root = fish_shell_quote(&root_str),
+                prefix = fish_shell_quote(&prefix_str)
             ),
         };
         let managed_block = format!("{ZB_BLOCK_START}{block_body}\n{ZB_BLOCK_END}\n");
@@ -415,37 +437,53 @@ end
                 zerobrew_bin,
                 prefix_bin.display()
             ))?;
-            ui.info(format!(
-                "Restart your terminal or run: source {}",
-                config_file
-            ))?;
+            let reload_command = match shell_kind {
+                ShellConfigKind::Posix => format!(". {}", posix_shell_quote(&config_file)),
+                ShellConfigKind::Fish => format!("source {}", fish_shell_quote(&config_file)),
+            };
+            ui.info(format!("Restart your terminal or run: {}", reload_command))?;
         }
     } else if no_modify_path {
         ui.info("Skipped shell configuration (--no-modify-path)")?;
         match shell_kind {
             ShellConfigKind::Posix => {
                 ui.info("Run this in your current shell:")?;
-                ui.println(format!("    export ZEROBREW_DIR={zerobrew_dir}"))?;
-                ui.println(format!("    export ZEROBREW_ROOT={}", root.display()))?;
-                ui.println(format!("    export ZEROBREW_PREFIX={}", prefix.display()))?;
                 ui.println(format!(
-                    "    export PATH=\"{}:{}:$PATH\"",
-                    zerobrew_bin,
-                    prefix_bin.display()
+                    "    export ZEROBREW_DIR={}",
+                    posix_shell_quote(zerobrew_dir)
+                ))?;
+                ui.println(format!(
+                    "    export ZEROBREW_ROOT={}",
+                    posix_shell_quote(&root_str)
+                ))?;
+                ui.println(format!(
+                    "    export ZEROBREW_PREFIX={}",
+                    posix_shell_quote(&prefix_str)
+                ))?;
+                ui.println(format!(
+                    "    export PATH={}:{}:$PATH",
+                    posix_shell_quote(zerobrew_bin),
+                    posix_shell_quote(&prefix_bin_str)
                 ))?;
             }
             ShellConfigKind::Fish => {
                 ui.info("Run this in your current shell:")?;
-                ui.println(format!("    set -gx ZEROBREW_DIR \"{zerobrew_dir}\""))?;
-                ui.println(format!("    set -gx ZEROBREW_ROOT \"{}\"", root.display()))?;
                 ui.println(format!(
-                    "    set -gx ZEROBREW_PREFIX \"{}\"",
-                    prefix.display()
+                    "    set -gx ZEROBREW_DIR {}",
+                    fish_shell_quote(zerobrew_dir)
                 ))?;
                 ui.println(format!(
-                    "    set -gx PATH \"{}\" \"{}\" $PATH",
-                    zerobrew_bin,
-                    prefix_bin.display()
+                    "    set -gx ZEROBREW_ROOT {}",
+                    fish_shell_quote(&root_str)
+                ))?;
+                ui.println(format!(
+                    "    set -gx ZEROBREW_PREFIX {}",
+                    fish_shell_quote(&prefix_str)
+                ))?;
+                ui.println(format!(
+                    "    set -gx PATH {} {} $PATH",
+                    fish_shell_quote(zerobrew_bin),
+                    fish_shell_quote(&prefix_bin_str)
                 ))?;
             }
         }
@@ -538,6 +576,22 @@ mod tests {
     static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn posix_shell_quote_preserves_spaces_and_single_quotes() {
+        assert_eq!(
+            posix_shell_quote("/tmp/zero brew/user's dir"),
+            "'/tmp/zero brew/user'\\''s dir'"
+        );
+    }
+
+    #[test]
+    fn fish_shell_quote_escapes_expansions() {
+        assert_eq!(
+            fish_shell_quote(r#"/tmp/zero brew/$root/"bin""#),
+            r#""/tmp/zero brew/\$root/\"bin\"""#
+        );
     }
 
     #[test]
@@ -643,10 +697,10 @@ mod tests {
         let content = fs::read_to_string(&shell_config).unwrap();
         assert!(content.contains(ZB_BLOCK_START));
         assert!(content.contains(ZB_BLOCK_END));
-        assert!(content.contains("export ZEROBREW_DIR=/home/user/.zerobrew"));
-        assert!(content.contains("export ZEROBREW_BIN=/home/user/.zerobrew/bin"));
-        assert!(content.contains(&format!("export ZEROBREW_ROOT={}", root.display())));
-        assert!(content.contains(&format!("export ZEROBREW_PREFIX={}", prefix.display())));
+        assert!(content.contains("export ZEROBREW_DIR='/home/user/.zerobrew'"));
+        assert!(content.contains("export ZEROBREW_BIN='/home/user/.zerobrew/bin'"));
+        assert!(content.contains(&format!("export ZEROBREW_ROOT='{}'", root.display())));
+        assert!(content.contains(&format!("export ZEROBREW_PREFIX='{}'", prefix.display())));
         assert!(content.contains("export PKG_CONFIG_PATH="));
         assert!(content.contains("/lib/pkgconfig"));
         assert!(
@@ -781,7 +835,7 @@ mod tests {
         // Managed block should be replaced, preserving unrelated user content
         let content = fs::read_to_string(&shell_config).unwrap();
         assert!(content.contains("export KEEP_ME=true"));
-        assert!(content.contains("export ZEROBREW_DIR=/home/user/.zerobrew"));
+        assert!(content.contains("export ZEROBREW_DIR='/home/user/.zerobrew'"));
         assert!(!content.contains("export ZEROBREW_DIR=/old"));
         assert_eq!(content.matches(ZB_BLOCK_START).count(), 1);
         assert_eq!(content.matches(ZB_BLOCK_END).count(), 1);


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [X] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [ ] I have not used AI for _any_ portion of this PR.

GPT 5.5 used to update install and update cadence / clarity.
 
<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

this PR improves the installer/readme flow around shell setup and updating zerobrew itself. the installer now shows `zb init` output instead of hiding it, prints the `source` command users should run after install, prints exact export commands when path modification is disabled, and reports whether rerunning the standalone installer installed, updated, or found zerobrew already current. it also warns if the current shell resolves `zb` from a different path than the one the installer just updated.



