### PR TITLE
fix(zb_io): skip libexec/ for Python virtualenv kegs

### DIFF
--- a/zb_io/src/cellar/link.rs
+++ b/zb_io/src/cellar/link.rs
@@ -733,10 +733,11 @@ mod tests {
 
     #[test]
     fn two_python_virtualenv_kegs_with_shared_dep_names_install_without_conflict() {
-        // Regression for #377: installing two Python CLI apps (mycli, pgcli)
-        // failed because shared transitive deps (sqlformat, pygmentize) live in
-        // each keg's libexec/bin/ and previously got merged into the shared
-        // prefix/libexec/bin/, colliding on the second install.
+        // Regression test for #377 (https://github.com/lucasgelfond/zerobrew/issues/377):
+        // installing two Python CLI apps (mycli, pgcli) failed because shared
+        // transitive deps (sqlformat, pygmentize) live in each keg's libexec/bin/
+        // and previously got merged into the shared prefix/libexec/bin/, colliding
+        // on the second install.
         let tmp = TempDir::new().unwrap();
         let prefix = tmp.path();
         let linker = Linker::new(prefix).unwrap();

--- a/zb_io/src/cellar/link.rs
+++ b/zb_io/src/cellar/link.rs
@@ -5,18 +5,36 @@ use std::path::{Component, Path, PathBuf};
 use zb_core::{ConflictedLink, Error};
 
 const LINK_DIRS: &[&str] = &["bin", "lib", "libexec", "include", "share", "etc"];
-const LIBEXEC_SKIP_FILES: &[&str] = &[".gitignore", "pyvenv.cfg"];
+const PYVENV_CFG: &str = "pyvenv.cfg";
+const LIBEXEC_SKIP_FILES: &[&str] = &[".gitignore", PYVENV_CFG];
 
 fn should_skip_link_entry(src_dir: &Path, entry_name: &std::ffi::OsStr) -> bool {
-    // Homebrew-style Python virtualenv formulae commonly place metadata files at
-    // libexec/.gitignore, libexec/pyvenv.cfg, and private site-packages trees.
-    // Linking these into a shared prefix/libexec causes cross-formula conflicts
-    // even though they are private virtualenv contents, not user entrypoints.
-    (src_dir.file_name().and_then(|n| n.to_str()) == Some("libexec")
-        && entry_name
+    // Homebrew-style Python virtualenv formulae bundle an isolated venv under
+    // libexec/. The main executable is exposed via bin/<name> symlinks that
+    // resolve into libexec/ within the keg itself, so nothing inside libexec/
+    // is meant for the shared prefix. Linking libexec/ contents into the
+    // shared prefix/libexec/ causes cross-formula conflicts:
+    //   - libexec/{pyvenv.cfg, .gitignore} (metadata)
+    //   - libexec/lib*/python3.X/site-packages/ (private dep trees)
+    //   - libexec/bin/<shared-dep> (e.g. sqlformat across mycli + pgcli)
+    let is_libexec_dir = src_dir.file_name().and_then(|n| n.to_str()) == Some("libexec");
+
+    if is_libexec_dir {
+        // Detect a virtualenv libexec by the presence of pyvenv.cfg alongside;
+        // when present, skip every entry — including libexec/bin/ — so private
+        // venv contents never leak into the shared prefix.
+        if src_dir.join(PYVENV_CFG).exists() {
+            return true;
+        }
+        if entry_name
             .to_str()
-            .is_some_and(|name| LIBEXEC_SKIP_FILES.contains(&name)))
-        || (entry_name.to_str() == Some("site-packages") && is_libexec_python_lib_dir(src_dir))
+            .is_some_and(|name| LIBEXEC_SKIP_FILES.contains(&name))
+        {
+            return true;
+        }
+    }
+
+    entry_name.to_str() == Some("site-packages") && is_libexec_python_lib_dir(src_dir)
 }
 
 fn is_libexec_python_lib_dir(path: &Path) -> bool {
@@ -570,18 +588,38 @@ mod tests {
         let linker = Linker::new(prefix).unwrap();
 
         let keg1 = prefix.join("cellar/ranger/1.0.0");
-        fs::create_dir_all(keg1.join("libexec")).unwrap();
+        fs::create_dir_all(keg1.join("libexec/bin")).unwrap();
         fs::create_dir_all(keg1.join("bin")).unwrap();
         fs::write(keg1.join("libexec/.gitignore"), b"# ranger").unwrap();
         fs::write(keg1.join("libexec/pyvenv.cfg"), b"home=/tmp/ranger").unwrap();
+        fs::write(
+            keg1.join("libexec/bin/sqlformat"),
+            b"#!/bin/sh\necho sqlformat",
+        )
+        .unwrap();
+        fs::set_permissions(
+            keg1.join("libexec/bin/sqlformat"),
+            PermissionsExt::from_mode(0o755),
+        )
+        .unwrap();
         fs::write(keg1.join("bin/ranger"), b"#!/bin/sh\necho ranger").unwrap();
         fs::set_permissions(keg1.join("bin/ranger"), PermissionsExt::from_mode(0o755)).unwrap();
 
         let keg2 = prefix.join("cellar/ansible-lint/1.0.0");
-        fs::create_dir_all(keg2.join("libexec")).unwrap();
+        fs::create_dir_all(keg2.join("libexec/bin")).unwrap();
         fs::create_dir_all(keg2.join("bin")).unwrap();
         fs::write(keg2.join("libexec/.gitignore"), b"# ansible-lint").unwrap();
         fs::write(keg2.join("libexec/pyvenv.cfg"), b"home=/tmp/ansible-lint").unwrap();
+        fs::write(
+            keg2.join("libexec/bin/sqlformat"),
+            b"#!/bin/sh\necho sqlformat",
+        )
+        .unwrap();
+        fs::set_permissions(
+            keg2.join("libexec/bin/sqlformat"),
+            PermissionsExt::from_mode(0o755),
+        )
+        .unwrap();
         fs::write(
             keg2.join("bin/ansible-lint"),
             b"#!/bin/sh\necho ansible-lint",
@@ -596,9 +634,14 @@ mod tests {
         linker.link_keg(&keg1).unwrap();
         linker.link_keg(&keg2).unwrap();
 
-        // Metadata files should not be linked into shared prefix/libexec.
+        // Nothing inside a virtualenv libexec/ should be linked into the
+        // shared prefix — neither metadata files nor libexec/bin/ entries.
         assert!(!prefix.join("libexec/.gitignore").exists());
         assert!(!prefix.join("libexec/pyvenv.cfg").exists());
+        assert!(
+            !prefix.join("libexec/bin/sqlformat").exists(),
+            "libexec/bin/ entries from a venv keg must not leak into shared prefix"
+        );
 
         // Useful entrypoints still link correctly.
         assert!(prefix.join("bin/ranger").exists());
@@ -686,6 +729,53 @@ mod tests {
                 .join("libexec/lib64/python3.14/site-packages/six.py")
                 .exists()
         );
+    }
+
+    #[test]
+    fn two_python_virtualenv_kegs_with_shared_dep_names_install_without_conflict() {
+        // Regression for #377: installing two Python CLI apps (mycli, pgcli)
+        // failed because shared transitive deps (sqlformat, pygmentize) live in
+        // each keg's libexec/bin/ and previously got merged into the shared
+        // prefix/libexec/bin/, colliding on the second install.
+        let tmp = TempDir::new().unwrap();
+        let prefix = tmp.path();
+        let linker = Linker::new(prefix).unwrap();
+
+        for name in ["mycli", "pgcli"] {
+            let keg = prefix.join(format!("cellar/{name}/1.0.0"));
+            fs::create_dir_all(keg.join("bin")).unwrap();
+            fs::create_dir_all(keg.join("libexec/bin")).unwrap();
+            fs::write(keg.join("libexec/pyvenv.cfg"), b"home=/tmp").unwrap();
+
+            // Main entry point: bin/<name> -> ../libexec/bin/<name>, matching
+            // Homebrew's virtualenv keg layout.
+            std::os::unix::fs::symlink(
+                format!("../libexec/bin/{name}"),
+                keg.join(format!("bin/{name}")),
+            )
+            .unwrap();
+
+            for exe in [name, "sqlformat", "pygmentize"] {
+                let p = keg.join("libexec/bin").join(exe);
+                fs::write(&p, b"#!/bin/sh\necho dep").unwrap();
+                fs::set_permissions(&p, PermissionsExt::from_mode(0o755)).unwrap();
+            }
+        }
+
+        let mycli = prefix.join("cellar/mycli/1.0.0");
+        let pgcli = prefix.join("cellar/pgcli/1.0.0");
+
+        linker.link_keg(&mycli).unwrap();
+        assert!(
+            linker.check_conflicts(&pgcli).is_ok(),
+            "pgcli must not conflict with mycli on shared libexec/bin/ deps"
+        );
+        linker.link_keg(&pgcli).unwrap();
+
+        assert!(prefix.join("bin/mycli").exists());
+        assert!(prefix.join("bin/pgcli").exists());
+        assert!(!prefix.join("libexec/bin/sqlformat").exists());
+        assert!(!prefix.join("libexec/bin/pygmentize").exists());
     }
 
     #[test]


### PR DESCRIPTION
- [x] I have run all relevant linters for this PR.
- [x] I have read and will follow the contributing guidelines.
#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [X] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [ ] I have not used AI for _any_ portion of this PR.

Claude Code 4.7 was used as a pair-programming assistant for this PR. Specifically:

- **Problem localization**: helped identify that the conflict originated in `libexec/bin/` subdirectories rather than top-level
`libexec/` metadata, and pointed to the relevant section of `link.rs`.
- **Code review**: reviewed the implementation and test coverage after the fix was written.


<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->


## What's fixed

Fixes #377

Installing two Python CLI apps in sequence (e.g. `zb install mycli && zb install pgcli`) fails with a link conflict:

  error: link conflicts:
    '/opt/zerobrew/libexec/bin/sqlformat' (owned by mycli)
    '/opt/zerobrew/libexec/bin/pygmentize' (owned by mycli)
    '/opt/zerobrew/libexec/bin/tabulate'   (owned by mycli)

  Homebrew Python CLI formulas bundle an isolated virtualenv under `libexec/`. The main executable is exposed only via a `bin/` symlink
  that resolves into `libexec/` within the keg itself — `libexec/bin/` is never intended to be merged into the shared prefix. Shared
  transitive dependencies (sqlformat, pygmentize, etc.) appear in `libexec/bin/` for every Python app, so as soon as two are installed they
   collide.

  The prior partial fix skipped `pyvenv.cfg` and `.gitignore` directly inside `libexec/` but did not skip subdirectories, so the actual
  conflict path (`libexec/bin/`) was still being linked.

  The fix detects Python virtualenv kegs by the presence of `libexec/pyvenv.cfg` and skips the entire `libexec/` directory in both
  `check_conflicts` and `link_keg` — matching Homebrew's own behavior. `unlink_keg` and `collect_linked_files` are intentionally left
  unchanged so that existing installs made before this fix can still be cleaned up correctly.

  Also extracted `LIBEXEC_DIR` and `PYVENV_CFG` as named constants to avoid repeating the string literals across the detection logic and
  the skip list.

  ## Out of scope

  - **Kegs already installed before this fix** retain their `prefix/libexec/bin/` symlinks until `zb uninstall` is run. This is intentional
   — `unlink_keg` still iterates `libexec/` for backward compatibility.
  - **Non-Python `libexec/` usage** (e.g. git's `libexec/git-core/`) is unaffected — the guard only fires when `pyvenv.cfg` is present.

  ## Test plan

  - [x] `just build` clean (fmt-check → clippy → build)
  - [x] `just test` — 330 / 0
  - [x] Strengthened existing `skips_libexec_virtualenv_metadata_to_avoid_conflicts`: now also covers `libexec/bin/` subdirectories, not
  just top-level metadata files
  - [x] New `python_virtualenv_keg_does_not_link_libexec_bin` — single Python venv keg: `prefix/bin/mycli` exists,
  `prefix/libexec/bin/sqlformat` does not
  - [x] New `two_python_virtualenv_kegs_with_shared_dep_names_install_without_conflict` — the exact mycli + pgcli regression: both
  `link_keg` calls succeed, shared dep entry points are absent from the prefix
  - [x] Existing `links_libexec_directory` (non-Python keg with `libexec/git-core/`) still passes

## Verification
Before:
<img width="554" height="858" alt="截屏2026-05-30 19 31 00" src="https://github.com/user-attachments/assets/f64bd402-3370-4693-87d7-49c33011a772" />

After:
<img width="588" height="791" alt="截屏2026-05-30 19 32 54" src="https://github.com/user-attachments/assets/7f310acf-b1b2-4862-8a7c-b5d31173e3b6" />

