### PR TITLE
fix(zb_io): replace same-formula and dangling symlinks when linking kegs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.95"
+          toolchain: "1.96"
           components: rustfmt
       
       - name: check formatting
@@ -44,7 +44,7 @@ jobs:
       - name: install rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.95"
+          toolchain: "1.96"
           components: clippy
       
       - name: cache rust dependencies
@@ -66,10 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: cargo audit
         uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          deny-warnings: true
           

--- a/.github/workflows/homebrew-compat.yml
+++ b/.github/workflows/homebrew-compat.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.95"
+          toolchain: "1.96"
 
       - name: Cache Cargo dependencies
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.95"
+          toolchain: "1.96"
           targets: ${{ matrix.target }}
 
       - name: Cache Rust dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,10 @@ jobs:
         include:
           - os: macos-latest
             name: macos-arm64
-            rust: "1.95"
+            rust: "1.96"
           - os: ubuntu-latest
             name: linux
-            rust: "1.95"
+            rust: "1.96"
     steps:
       - uses: actions/checkout@v4
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Bump MSRV to 1.96, required to build the latest `cargo-audit` in CI ([#393](https://github.com/lucasgelfond/zerobrew/pull/393))
+- Refresh `Cargo.lock` for audit findings: `crossbeam-epoch` (RUSTSEC-2026-0204), `quinn-proto` (RUSTSEC-2026-0185), and `anyhow` (RUSTSEC-2026-0190) ([#393](https://github.com/lucasgelfond/zerobrew/pull/393))
+
 ### Fixed
 - Relink on upgrade/reinstall: symlinks owned by another version of the same formula — including dangling links left behind by removed kegs — are now replaced during linking instead of failing the link step as conflicts with the formula itself, which left `bin`/`opt` pointing at the old version while the DB reported the new one ([#393](https://github.com/lucasgelfond/zerobrew/pull/393))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Relink on upgrade/reinstall: symlinks owned by another version of the same formula — including dangling links left behind by removed kegs — are now replaced during linking instead of failing the link step as conflicts with the formula itself, which left `bin`/`opt` pointing at the old version while the DB reported the new one ([#393](https://github.com/lucasgelfond/zerobrew/pull/393))
+
 ## [0.3.2] - 2026-06-11
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arwen"
@@ -195,6 +195,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "chrono"
@@ -350,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -657,11 +668,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -671,10 +680,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1435,15 +1447,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1484,15 +1487,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1541,31 +1545,28 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3056,26 +3057,6 @@ dependencies = [
  "zb_core",
  "zip",
  "zstd",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.package]
 version = "0.3.2"
-rust-version = "1.95"
+rust-version = "1.96"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "fs", "process"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95"
+channel = "1.96"

--- a/zb_io/src/cellar/link.rs
+++ b/zb_io/src/cellar/link.rs
@@ -102,15 +102,62 @@ fn keg_name_from_path(path: &Path) -> Option<String> {
     None
 }
 
-fn keg_name_from_symlink(dst: &Path) -> Option<String> {
+/// Strip `.` and resolve `..` components without touching the filesystem, so
+/// dangling symlink targets can still be attributed to a keg.
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Read the symlink at `dst` and resolve a relative target against its parent
+/// directory. Returns `None` when `dst` is not a symlink.
+fn resolve_link_target(dst: &Path) -> Option<PathBuf> {
     let target = fs::read_link(dst).ok()?;
-    let resolved = if target.is_relative() {
+    Some(if target.is_relative() {
         dst.parent().unwrap_or(Path::new("")).join(&target)
     } else {
         target
+    })
+}
+
+fn keg_name_from_symlink(dst: &Path) -> Option<String> {
+    let resolved = resolve_link_target(dst)?;
+    match fs::canonicalize(&resolved) {
+        Ok(canonical) => keg_name_from_path(&canonical),
+        // Dangling link (e.g. the keg it pointed into was removed): the
+        // target path still identifies the owning keg.
+        Err(_) => keg_name_from_path(&normalize_lexically(&resolved)),
+    }
+}
+
+/// Whether the symlink at `dst` may be silently replaced by a link to `src`.
+///
+/// Regression guard for #331 (https://github.com/lucasgelfond/zerobrew/issues/331):
+/// upgrades and reinstalls used to report the previous version's symlinks as
+/// conflicts "belonging to" the formula itself, leaving the prefix pointing at
+/// the old keg. A link is replaceable when it belongs to another version of
+/// the same keg, or when its target no longer exists (dead links block fresh
+/// installs but protect nothing).
+fn can_replace_existing_link(src: &Path, dst: &Path) -> bool {
+    let Some(resolved) = resolve_link_target(dst) else {
+        return false;
     };
-    let canonical = fs::canonicalize(&resolved).ok()?;
-    keg_name_from_path(&canonical)
+    if !resolved.exists() {
+        return true;
+    }
+    match (keg_name_from_symlink(dst), keg_name_from_path(src)) {
+        (Some(old_owner), Some(new_owner)) => old_owner == new_owner,
+        _ => false,
+    }
 }
 
 impl Linker {
@@ -196,6 +243,9 @@ impl Linker {
                     if fs::canonicalize(&resolved).ok() == fs::canonicalize(&src_path).ok() {
                         continue;
                     }
+                    if can_replace_existing_link(&src_path, &dst_path) {
+                        continue;
+                    }
                 }
                 conflicts.push(ConflictedLink {
                     path: dst_path.clone(),
@@ -245,6 +295,14 @@ impl Linker {
             if matching_old.exists()
                 && fs::canonicalize(&matching_old).ok() != fs::canonicalize(&src_path).ok()
             {
+                // Another version of the same keg (upgrade through a legacy
+                // whole-directory symlink) will be replaced during linking.
+                let old_owner = fs::canonicalize(&matching_old)
+                    .ok()
+                    .and_then(|p| keg_name_from_path(&p));
+                if old_owner.is_some() && old_owner == keg_name_from_path(&src_path) {
+                    continue;
+                }
                 conflicts.push(ConflictedLink {
                     path: dst_path,
                     owned_by: keg_name_from_symlink(dst).or_else(|| keg_name_from_path(old_target)),
@@ -288,10 +346,19 @@ impl Linker {
             // into individual file symlinks instead of conflicting.
             if src_path.is_dir() {
                 if dst_path.symlink_metadata().is_ok() && dst_path.is_symlink() {
-                    let old_target = fs::read_link(&dst_path)
+                    let target = fs::read_link(&dst_path)
                         .map_err(Error::store("failed to read symlink target"))?;
+                    let old_target = if target.is_relative() {
+                        dst_path.parent().unwrap_or(Path::new("")).join(&target)
+                    } else {
+                        target
+                    };
                     let _ = fs::remove_file(&dst_path);
-                    Self::link_recursive(&old_target, &dst_path)?;
+                    // A dangling directory symlink (e.g. the old keg was
+                    // removed) has nothing left to expand.
+                    if old_target.exists() {
+                        Self::link_recursive(&old_target, &dst_path)?;
+                    }
                 }
                 linked.extend(Self::link_recursive(&src_path, &dst_path)?);
                 continue;
@@ -314,6 +381,8 @@ impl Linker {
                         } else {
                             let _ = fs::remove_file(&dst_path);
                         }
+                    } else if can_replace_existing_link(&src_path, &dst_path) {
+                        let _ = fs::remove_file(&dst_path);
                     } else {
                         return Err(Error::LinkConflict {
                             conflicts: vec![ConflictedLink {
@@ -923,5 +992,179 @@ mod tests {
         linker.link_keg(&keg1).unwrap();
         // Pre-flight check should pass since the files don't overlap
         assert!(linker.check_conflicts(&keg2).is_ok());
+    }
+
+    #[test]
+    fn upgrade_relinks_same_formula_to_new_version() {
+        // Regression test for #331 (https://github.com/lucasgelfond/zerobrew/issues/331):
+        // installing a newer version of an already-linked formula reported the
+        // old version's symlinks as conflicts "belonging to" the formula
+        // itself, so the prefix kept pointing at the old keg forever.
+        let tmp = TempDir::new().unwrap();
+        let prefix = tmp.path();
+        let linker = Linker::new(prefix).unwrap();
+
+        let old_keg = prefix.join("cellar/gh/1.0.0");
+        fs::create_dir_all(old_keg.join("bin")).unwrap();
+        fs::create_dir_all(old_keg.join("share/man/man1")).unwrap();
+        fs::write(old_keg.join("bin/gh"), b"old").unwrap();
+        fs::write(old_keg.join("share/man/man1/gh.1"), b"old man").unwrap();
+        linker.link_keg(&old_keg).unwrap();
+
+        let new_keg = prefix.join("cellar/gh/2.0.0");
+        fs::create_dir_all(new_keg.join("bin")).unwrap();
+        fs::create_dir_all(new_keg.join("share/man/man1")).unwrap();
+        fs::write(new_keg.join("bin/gh"), b"new").unwrap();
+        fs::write(new_keg.join("share/man/man1/gh.1"), b"new man").unwrap();
+
+        assert!(
+            linker.check_conflicts(&new_keg).is_ok(),
+            "another version of the same formula must not count as a conflict"
+        );
+        linker.link_keg(&new_keg).unwrap();
+
+        for link in ["bin/gh", "share/man/man1/gh.1"] {
+            let target = fs::read_link(prefix.join(link)).unwrap();
+            let target = target.to_string_lossy();
+            assert!(
+                target.contains("2.0.0"),
+                "{link} must point at 2.0.0, got {target}"
+            );
+        }
+    }
+
+    #[test]
+    fn relinks_when_old_keg_directory_was_removed() {
+        // #331 fallout: an upgrade that removed the old keg but died before
+        // relinking leaves dangling same-formula symlinks; the next install
+        // must replace them instead of conflicting.
+        let tmp = TempDir::new().unwrap();
+        let prefix = tmp.path();
+        let linker = Linker::new(prefix).unwrap();
+
+        let old_keg = setup_keg(&tmp, "foo");
+        linker.link_keg(&old_keg).unwrap();
+        fs::remove_dir_all(&old_keg).unwrap();
+        assert!(prefix.join("bin/foo").is_symlink());
+
+        let new_keg = prefix.join("cellar/foo/2.0.0");
+        fs::create_dir_all(new_keg.join("bin")).unwrap();
+        fs::write(new_keg.join("bin/foo"), b"new").unwrap();
+
+        assert!(linker.check_conflicts(&new_keg).is_ok());
+        linker.link_keg(&new_keg).unwrap();
+
+        let target = fs::read_link(prefix.join("bin/foo")).unwrap();
+        assert!(target.to_string_lossy().contains("2.0.0"));
+        assert!(prefix.join("bin/foo").exists(), "link must not be dangling");
+    }
+
+    #[test]
+    fn replaces_dangling_symlink_from_other_formula() {
+        // Orphaned links whose keg no longer exists (#188 fallout) used to
+        // block unrelated installs with phantom conflicts. A dead link
+        // protects nothing and is safe to replace.
+        let tmp = TempDir::new().unwrap();
+        let prefix = tmp.path();
+        let linker = Linker::new(prefix).unwrap();
+
+        std::os::unix::fs::symlink(
+            prefix.join("cellar/ghost/1.0.0/bin/tool"),
+            prefix.join("bin/tool"),
+        )
+        .unwrap();
+
+        let keg = prefix.join("cellar/tool/1.0.0");
+        fs::create_dir_all(keg.join("bin")).unwrap();
+        fs::write(keg.join("bin/tool"), b"real").unwrap();
+
+        assert!(linker.check_conflicts(&keg).is_ok());
+        linker.link_keg(&keg).unwrap();
+
+        let target = fs::read_link(prefix.join("bin/tool")).unwrap();
+        assert!(target.to_string_lossy().contains("cellar/tool/1.0.0"));
+    }
+
+    #[test]
+    fn live_symlink_from_other_formula_still_conflicts() {
+        // Replacement is limited to same-formula and dead links; a live link
+        // owned by a different formula must keep failing all-or-none.
+        let tmp = TempDir::new().unwrap();
+        let prefix = tmp.path();
+        let linker = Linker::new(prefix).unwrap();
+
+        let keg1 = setup_keg(&tmp, "alpha");
+        linker.link_keg(&keg1).unwrap();
+
+        let keg2 = prefix.join("cellar/beta/1.0.0");
+        fs::create_dir_all(keg2.join("bin")).unwrap();
+        fs::write(keg2.join("bin/alpha"), b"other").unwrap();
+
+        let result = linker.check_conflicts(&keg2);
+        assert!(result.is_err());
+        if let Err(Error::LinkConflict { conflicts }) = result {
+            assert_eq!(conflicts[0].owned_by.as_deref(), Some("alpha"));
+        }
+        assert!(linker.link_keg(&keg2).is_err());
+        let target = fs::read_link(prefix.join("bin/alpha")).unwrap();
+        assert!(target.to_string_lossy().contains("alpha/1.0.0"));
+    }
+
+    #[test]
+    fn upgrade_expands_legacy_directory_symlink_owned_by_same_formula() {
+        // Whole-directory symlinks left by older layouts must be expanded and
+        // replaced when the owning formula is upgraded, not reported as a
+        // conflict for every file inside.
+        let tmp = TempDir::new().unwrap();
+        let prefix = tmp.path();
+        let linker = Linker::new(prefix).unwrap();
+
+        let old_keg = prefix.join("cellar/foo/1.0.0");
+        fs::create_dir_all(old_keg.join("share/doc/foo")).unwrap();
+        fs::write(old_keg.join("share/doc/foo/README"), b"old").unwrap();
+        fs::create_dir_all(prefix.join("share/doc")).unwrap();
+        std::os::unix::fs::symlink(old_keg.join("share/doc/foo"), prefix.join("share/doc/foo"))
+            .unwrap();
+
+        let new_keg = prefix.join("cellar/foo/2.0.0");
+        fs::create_dir_all(new_keg.join("share/doc/foo")).unwrap();
+        fs::write(new_keg.join("share/doc/foo/README"), b"new").unwrap();
+
+        assert!(linker.check_conflicts(&new_keg).is_ok());
+        linker.link_keg(&new_keg).unwrap();
+
+        let readme = prefix.join("share/doc/foo/README");
+        let target = fs::read_link(&readme).unwrap();
+        assert!(target.to_string_lossy().contains("2.0.0"));
+    }
+
+    #[test]
+    fn dangling_directory_symlink_is_replaced() {
+        let tmp = TempDir::new().unwrap();
+        let prefix = tmp.path();
+        let linker = Linker::new(prefix).unwrap();
+
+        std::os::unix::fs::symlink(
+            prefix.join("cellar/foo/0.9.0/share/foo"),
+            prefix.join("share/foo"),
+        )
+        .unwrap();
+
+        let keg = prefix.join("cellar/foo/1.0.0");
+        fs::create_dir_all(keg.join("share/foo")).unwrap();
+        fs::write(keg.join("share/foo/data.txt"), b"data").unwrap();
+
+        assert!(linker.check_conflicts(&keg).is_ok());
+        linker.link_keg(&keg).unwrap();
+
+        assert!(prefix.join("share/foo/data.txt").exists());
+    }
+
+    #[test]
+    fn keg_name_from_symlink_attributes_dangling_links() {
+        let tmp = TempDir::new().unwrap();
+        let link = tmp.path().join("gh");
+        std::os::unix::fs::symlink(tmp.path().join("cellar/gh/1.0.0/bin/gh"), &link).unwrap();
+        assert_eq!(keg_name_from_symlink(&link).as_deref(), Some("gh"));
     }
 }

--- a/zb_io/src/installer/install/upgrade.rs
+++ b/zb_io/src/installer/install/upgrade.rs
@@ -244,6 +244,97 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn plain_install_over_older_version_relinks_to_new_version() {
+        // Regression test for #331 (https://github.com/lucasgelfond/zerobrew/issues/331):
+        // `zb install <pkg>` with an older version already installed failed
+        // the link step with conflicts "belonging to" the package itself,
+        // leaving the DB reporting the new version while bin/<pkg> kept
+        // resolving to the old keg.
+        let mock_server = MockServer::start().await;
+        let tmp = TempDir::new().unwrap();
+        let tag = get_test_bottle_tag();
+
+        let bottle_v1 = create_bottle_tarball_with_version("relinkpkg", "1.0.0");
+        let sha_v1 = sha256_hex(&bottle_v1);
+        let bottle_v2 = create_bottle_tarball_with_version("relinkpkg", "2.0.0");
+        let sha_v2 = sha256_hex(&bottle_v2);
+
+        Mock::given(method("GET"))
+            .and(path("/formula/relinkpkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json(
+                &mock_server.uri(),
+                "relinkpkg",
+                "1.0.0",
+                tag,
+                &sha_v1,
+            )))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/bottles/relinkpkg-1.0.0.{tag}.bottle.tar.gz"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle_v1))
+            .up_to_n_times(1)
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/formula/relinkpkg.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(formula_json(
+                &mock_server.uri(),
+                "relinkpkg",
+                "2.0.0",
+                tag,
+                &sha_v2,
+            )))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/bottles/relinkpkg-2.0.0.{tag}.bottle.tar.gz"
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(bottle_v2))
+            .mount(&mock_server)
+            .await;
+
+        let root = tmp.path().join("zerobrew");
+        let prefix = tmp.path().join("homebrew");
+        let mut installer = make_installer(&root, &prefix, &mock_server.uri());
+
+        installer
+            .install(&["relinkpkg".to_string()], true)
+            .await
+            .unwrap();
+        let bin_link = prefix.join("bin/relinkpkg");
+        assert!(
+            fs::read_link(&bin_link)
+                .unwrap()
+                .to_string_lossy()
+                .contains("1.0.0")
+        );
+
+        installer
+            .install(&["relinkpkg".to_string()], true)
+            .await
+            .expect("install over an older version must not fail the link step");
+
+        let target = fs::read_link(&bin_link).unwrap();
+        let target_str = target.to_string_lossy();
+        assert!(
+            target_str.contains("2.0.0"),
+            "bin symlink must point at 2.0.0, got {target_str}"
+        );
+        assert!(bin_link.exists(), "bin symlink must not be dangling");
+
+        let opt_target = fs::read_link(prefix.join("opt/relinkpkg")).unwrap();
+        assert!(opt_target.to_string_lossy().contains("2.0.0"));
+
+        let installed = installer.get_installed("relinkpkg").unwrap();
+        assert_eq!(installed.version, "2.0.0");
+    }
+
+    #[tokio::test]
     async fn upgrade_with_no_link_does_not_create_symlinks() {
         let mock_server = MockServer::start().await;
         let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
- [X] I have run all relevant linters for this PR.
- [X] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [X] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [ ] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

Upgrades and reinstalls failed the link step because symlinks owned by an older version of the same formula were reported as conflicts, leaving bin/opt pointing at the old keg while the DB recorded the new version. Treat links owned by another version of the same keg — and dangling links whose target keg was removed — as replaceable in both the conflict pre-flight and the link step. Live links owned by other formulas still fail all-or-none.

Fixes #331

**AI Disclosure**: Fable 5 via Claude Code wrote all tests for this change.

