### PR TITLE
fix(zb_core): do not assume versioned packages are keg-only- #399

### DIFF
--- a/zb_core/src/formula/types.rs
+++ b/zb_core/src/formula/types.rs
@@ -394,21 +394,6 @@ mod tests {
     }
 
     #[test]
-    fn versioned_formula_is_keg_only() {
-        let json = r#"{
-            "name": "postgresql@15",
-            "versions": { "stable": "15.8" },
-            "dependencies": [],
-            "bottle": { "stable": { "files": {
-                "arm64_sonoma": { "url": "https://x.com/a.tar.gz", "sha256": "aa" }
-            }}}
-        }"#;
-        let formula: Formula = serde_json::from_str(json).unwrap();
-        assert_eq!(formula.keg_only, KegOnly::No);
-        assert!(formula.is_keg_only());
-    }
-
-    #[test]
     fn keg_only_reason_deserializes_provided_by_macos() {
         let json = r#"{
             "name": "sqlite",

--- a/zb_core/src/formula/types.rs
+++ b/zb_core/src/formula/types.rs
@@ -146,9 +146,6 @@ impl Formula {
     }
 
     pub fn is_keg_only(&self) -> bool {
-        if self.name.contains('@') {
-            return true;
-        }
         if matches!(self.keg_only, KegOnly::No) {
             return false;
         }


### PR DESCRIPTION
- [x] I have run all relevant linters for this PR.
- [x] I have read and will follow the contributing guidelines.

#

<!--
If you used AI assistance for any part of this pull request (code, documentation, or any other contributions), you must disclose this by checking the last box in this PR template and, if possible, add a note in your PR description specifying what was generated or significantly assisted by AI. This helps us ensure transparency and maintain a high standard for review. Thank you!
-->

- [ ] AI was used in this PR to generate code, documentation, or other changes, and I have explained _how_ it was used below. I understand that if I do not adhere to disclosing AI usage, my PR can be closed, even without explanation.
- [x] I have not used AI for _any_ portion of this PR.

<!--
Now you may use this space to discuss any other relevant information about this PR as well as link any related issues or PRs.
-->

#207 adds important functionality involving links and respecting keg-only packages, but incorrectly assumes (as did I) that all versioned packages must be keg-only. For postgresql@14/15, the example in my original issue #188, this is true, but there are some versioned packages which don't have conflicting links, i.e. gcc@13/14. These have versioned binaries, i.e. g++-13 and g++-14, so there's no link conflict and the formula json correctly does not mark them as keg-only, and so we should respect that, as Homebrew already does. This PR also removes the test that checks for this incorrect assumption.
